### PR TITLE
Configure pkgdown site

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,89 @@
+name: pkgdown
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pkgdown-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  R_KEEP_PKG_SOURCE: yes
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: stable
+
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: src/rust -> target
+          key: pkgdown
+
+      - name: Install R
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+        with:
+          use-public-rspm: true
+
+      - name: Install Pandoc
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+
+      - name: Install site dependencies
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+          cache-version: 1
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Upload site artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs
+
+  deploy:
+    name: Deploy site
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Deploy site
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Authors@R:
 Description: Connects R to Delta Sharing servers for share discovery, table
   metadata, snapshot reads, and change data feed reads.
 License: Apache License (>= 2) | file LICENSE
-URL: https://github.com/zacdav-db/delta-sharing-r
+URL: https://zacdav-db.github.io/delta-sharing-r/,
+  https://github.com/zacdav-db/delta-sharing-r
 BugReports: https://github.com/zacdav-db/delta-sharing-r/issues
 Depends:
   R (>= 4.3.0)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 An R client for [Delta Sharing](https://delta.io/sharing/), backed by
 [Delta Kernel](https://docs.delta.io/kernel/rust/introduction.html) and Arrow.
 
+See the [package website](https://zacdav-db.github.io/delta-sharing-r/) for the
+complete reference and introductory guide.
+
 ## Installation
 
 ```r

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # delta.sharing <img src="https://user-images.githubusercontent.com/1446829/144671151-b095e1b9-2d24-4d3b-b3c6-a7041e491077.png" align="right" width="180" alt="Delta Sharing logo" />
 
+[![R CMD check](https://github.com/zacdav-db/delta-sharing-r/actions/workflows/package-check.yaml/badge.svg)](https://github.com/zacdav-db/delta-sharing-r/actions/workflows/package-check.yaml)
+[![Codecov](https://codecov.io/gh/zacdav-db/delta-sharing-r/branch/main/graph/badge.svg)](https://app.codecov.io/gh/zacdav-db/delta-sharing-r)
+
 An R client for [Delta Sharing](https://delta.io/sharing/), backed by
 [Delta Kernel](https://docs.delta.io/kernel/rust/introduction.html) and Arrow.
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,28 @@
+url: https://zacdav-db.github.io/delta-sharing-r/
+
+template:
+  bootstrap: 5
+
+navbar:
+  structure:
+    left: [intro, reference, articles]
+    right: [search, github]
+
+reference:
+  - title: Connect and discover
+    desc: Create a client, discover shared data, and obtain table handles.
+    contents:
+      - sharing_client
+      - SharingClient
+      - SharingTable
+  - title: Read shared data
+    desc: Configure snapshot and change data feed reads.
+    contents:
+      - SharingSnapshot
+      - SharingChanges
+
+articles:
+  - title: Get started
+    navbar: ~
+    contents:
+      - delta-sharing


### PR DESCRIPTION
## Summary

- add a canonical pkgdown configuration for the public API and introductory guide
- build the site on pull requests and deploy from `main` with GitHub Pages
- isolate Pages write/OIDC permissions to the deployment job and pin every external Action to an immutable SHA
- link the package website from `DESCRIPTION` and `README.md`
- add README badges for the cross-platform package check and Codecov

Generated site output remains ephemeral and is not committed.

## Validation

- built the complete site locally with `pkgdown::build_site_github_pages()`
- verified the homepage, grouped reference index, vignette, sitemap, search assets, and `.nojekyll`
- verified both README badge endpoints and their rendered pkgdown homepage output
- parsed the workflow YAML and verified all nine Action references are SHA-pinned
- verified build/deploy permission boundaries
- ran `git diff --check` and credential/profile-value scans
- passed the hosted pkgdown build on the initial PR commit

## Coverage status

Codecov is active and holds a historical 90.36% report for the private integration branch. There is not yet a `main` report because the published package intentionally excludes the private test suite and its coverage workflow. The badge targets `main` and will honestly report that state until coverage publishing is restored separately.

## Deployment

After merge, pushes to `main` publish the generated `docs/` artifact to the `github-pages` environment at <https://zacdav-db.github.io/delta-sharing-r/>.
