### PR TITLE
Document consumer read performance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Suggests:
   arrow,
   DBI,
   duckdb,
+  httpuv,
   knitr,
   rmarkdown,
   testthat (>= 3.0.0),

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# delta.sharing <img src="https://user-images.githubusercontent.com/1446829/144671151-b095e1b9-2d24-4d3b-b3c6-a7041e491077.png" align="right" width="180" alt="Delta Sharing logo" />
+# delta.sharing <img src="https://user-images.githubusercontent.com/1446829/144671151-b095e1b9-2d24-4d3b-b3c6-a7041e491077.png" align="right" width="140" alt="Delta Sharing logo" />
 
 [![R CMD check](https://github.com/zacdav-db/delta-sharing-r/actions/workflows/package-check.yaml/badge.svg)](https://github.com/zacdav-db/delta-sharing-r/actions/workflows/package-check.yaml)
 [![Codecov](https://codecov.io/gh/zacdav-db/delta-sharing-r/branch/main/graph/badge.svg)](https://app.codecov.io/gh/zacdav-db/delta-sharing-r)

--- a/README.md
+++ b/README.md
@@ -120,12 +120,8 @@ several times.
 
 ## Performance
 
-The following are directional end-to-end snapshot measurements on consumer
-hardware, not isolated in-memory benchmarks.
-
-Each case read six columns from the same remote Delta table with
-`snapshot(limit = ..., response_format = "delta")$to_data_frame()`. Results are
-medians of three sequential reads after one warm-up read.
+Directional end-to-end snapshot results, reported as medians of three reads
+after one warm-up.
 
 *Apple M2 Pro MacBook Pro, 32 GB RAM, R 4.5.1; VPN connection: 93 Mbps
 down, 115 ms base round-trip latency.*
@@ -135,23 +131,3 @@ down, 115 ms base round-trip latency.*
 | 10,000 | 0.38 MiB | 5.83 s (5.82–7.77) | 1,700 |
 | 1,000,000 | 38.15 MiB | 11.91 s (11.33–25.66) | 84,000 |
 | 10,000,000 | 381.47 MiB | 71.49 s (66.36–71.79) | 140,000 |
-
-Elapsed time includes the Sharing query, signed-file access, Delta Kernel scan,
-Arrow streaming, and conversion to a data frame. The reported size is the
-materialized R object size, not bytes transferred over the network. Remote
-storage, file layout, server-side pruning, and network conditions can all
-change these results. For large reads, `to_arrow_stream()` or
-`to_arrow_reader()` keeps the result lazy instead of holding the complete data
-frame in memory.
-
-### Change data feed
-
-A four-version CDF read materialized 3.5 million rows from hundreds of small
-remote change files.
-
-*Apple M2 Pro MacBook Pro, 32 GB RAM, R 4.5.1; VPN connection: 101 Mbps
-down, 200 ms idle latency.*
-
-| Scope | Result shape | Materialized R size | Elapsed | Rows/s |
-|---|---:|---:|---:|---:|
-| Versions 1–4 | 3,500,000 × 7 | 173.57 MiB | 428.03 s | 8,200 |

--- a/README.md
+++ b/README.md
@@ -72,32 +72,6 @@ orders$changes(
 
 See `vignette("delta-sharing")` for a full walkthrough.
 
-## Performance
-
-The following are directional end-to-end snapshot measurements on consumer
-hardware, not isolated in-memory benchmarks. They were recorded on 7 August
-2026 using a 12-core Apple M2 Pro MacBook Pro with 32 GB RAM and R 4.5.1. The
-active VPN-routed internet connection measured 93 Mbps down with 115 ms base
-round-trip latency immediately before the run.
-
-Each case read six columns from the same remote Delta table with
-`snapshot(limit = ..., response_format = "delta")$to_data_frame()`. Results are
-medians of three sequential reads after one warm-up read.
-
-| Rows | Materialized R size | Elapsed, median (range) | Median rows/s |
-|---:|---:|---:|---:|
-| 10,000 | 0.38 MiB | 5.83 s (5.82–7.77) | 1,700 |
-| 1,000,000 | 38.15 MiB | 11.91 s (11.33–25.66) | 84,000 |
-| 10,000,000 | 381.47 MiB | 71.49 s (66.36–71.79) | 140,000 |
-
-Elapsed time includes the Sharing query, signed-file access, Delta Kernel scan,
-Arrow streaming, and conversion to a data frame. The reported size is the
-materialized R object size, not bytes transferred over the network. Remote
-storage, file layout, server-side pruning, and network conditions can all
-change these results. For large reads, `to_arrow_stream()` or
-`to_arrow_reader()` keeps the result lazy instead of holding the complete data
-frame in memory.
-
 ## Query with DuckDB
 
 DuckDB accepts both Arrow materializers:
@@ -143,3 +117,46 @@ duckdb::duckdb_register_arrow(con, "shared_orders", arrow_table)
 An Arrow reader is single-consumer. Use an Arrow table, or create a temporary
 DuckDB table during the first query, when the result needs to be scanned
 several times.
+
+## Performance
+
+The following are directional end-to-end snapshot measurements on consumer
+hardware, not isolated in-memory benchmarks. They were recorded on 7 August
+2026 using a 12-core Apple M2 Pro MacBook Pro with 32 GB RAM and R 4.5.1. The
+active VPN-routed internet connection measured 93 Mbps down with 115 ms base
+round-trip latency immediately before the run.
+
+Each case read six columns from the same remote Delta table with
+`snapshot(limit = ..., response_format = "delta")$to_data_frame()`. Results are
+medians of three sequential reads after one warm-up read.
+
+| Rows | Materialized R size | Elapsed, median (range) | Median rows/s |
+|---:|---:|---:|---:|
+| 10,000 | 0.38 MiB | 5.83 s (5.82–7.77) | 1,700 |
+| 1,000,000 | 38.15 MiB | 11.91 s (11.33–25.66) | 84,000 |
+| 10,000,000 | 381.47 MiB | 71.49 s (66.36–71.79) | 140,000 |
+
+Elapsed time includes the Sharing query, signed-file access, Delta Kernel scan,
+Arrow streaming, and conversion to a data frame. The reported size is the
+materialized R object size, not bytes transferred over the network. Remote
+storage, file layout, server-side pruning, and network conditions can all
+change these results. For large reads, `to_arrow_stream()` or
+`to_arrow_reader()` keeps the result lazy instead of holding the complete data
+frame in memory.
+
+### Change data feed
+
+A separate CDF read on 8 August 2026 used the same laptop and materialized a
+four-version, non-deletion-vector change range with `changes()` and
+`to_data_frame()`. The connection measured 101 Mbps down with 200 ms idle
+latency immediately before the run.
+
+| Scope | Result shape | Materialized R size | Elapsed | Rows/s |
+|---|---:|---:|---:|---:|
+| Versions 1–4 | 3,500,000 × 7 | 173.57 MiB | 428.03 s | 8,200 |
+
+This is one end-to-end observation rather than a median because the read took
+more than seven minutes. The fixture contains hundreds of small remote change
+files, so signed-file request latency dominates its wall time. It illustrates a
+many-file CDF workload and should not be compared directly with the compact
+snapshot rows-per-second figures above.

--- a/README.md
+++ b/README.md
@@ -121,14 +121,14 @@ several times.
 ## Performance
 
 The following are directional end-to-end snapshot measurements on consumer
-hardware, not isolated in-memory benchmarks. They were recorded on 7 August
-2026 using a 12-core Apple M2 Pro MacBook Pro with 32 GB RAM and R 4.5.1. The
-active VPN-routed internet connection measured 93 Mbps down with 115 ms base
-round-trip latency immediately before the run.
+hardware, not isolated in-memory benchmarks.
 
 Each case read six columns from the same remote Delta table with
 `snapshot(limit = ..., response_format = "delta")$to_data_frame()`. Results are
 medians of three sequential reads after one warm-up read.
+
+*Apple M2 Pro MacBook Pro, 32 GB RAM, R 4.5.1; VPN connection: 93 Mbps
+down, 115 ms base round-trip latency.*
 
 | Rows | Materialized R size | Elapsed, median (range) | Median rows/s |
 |---:|---:|---:|---:|
@@ -146,17 +146,12 @@ frame in memory.
 
 ### Change data feed
 
-A separate CDF read on 8 August 2026 used the same laptop and materialized a
-four-version, non-deletion-vector change range with `changes()` and
-`to_data_frame()`. The connection measured 101 Mbps down with 200 ms idle
-latency immediately before the run.
+A four-version CDF read materialized 3.5 million rows from hundreds of small
+remote change files.
+
+*Apple M2 Pro MacBook Pro, 32 GB RAM, R 4.5.1; VPN connection: 101 Mbps
+down, 200 ms idle latency.*
 
 | Scope | Result shape | Materialized R size | Elapsed | Rows/s |
 |---|---:|---:|---:|---:|
 | Versions 1–4 | 3,500,000 × 7 | 173.57 MiB | 428.03 s | 8,200 |
-
-This is one end-to-end observation rather than a median because the read took
-more than seven minutes. The fixture contains hundreds of small remote change
-files, so signed-file request latency dominates its wall time. It illustrates a
-many-file CDF workload and should not be compared directly with the compact
-snapshot rows-per-second figures above.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,32 @@ orders$changes(
 
 See `vignette("delta-sharing")` for a full walkthrough.
 
+## Performance
+
+The following are directional end-to-end snapshot measurements on consumer
+hardware, not isolated in-memory benchmarks. They were recorded on 7 August
+2026 using a 12-core Apple M2 Pro MacBook Pro with 32 GB RAM and R 4.5.1. The
+active VPN-routed internet connection measured 93 Mbps down with 115 ms base
+round-trip latency immediately before the run.
+
+Each case read six columns from the same remote Delta table with
+`snapshot(limit = ..., response_format = "delta")$to_data_frame()`. Results are
+medians of three sequential reads after one warm-up read.
+
+| Rows | Materialized R size | Elapsed, median (range) | Median rows/s |
+|---:|---:|---:|---:|
+| 10,000 | 0.38 MiB | 5.83 s (5.82–7.77) | 1,700 |
+| 1,000,000 | 38.15 MiB | 11.91 s (11.33–25.66) | 84,000 |
+| 10,000,000 | 381.47 MiB | 71.49 s (66.36–71.79) | 140,000 |
+
+Elapsed time includes the Sharing query, signed-file access, Delta Kernel scan,
+Arrow streaming, and conversion to a data frame. The reported size is the
+materialized R object size, not bytes transferred over the network. Remote
+storage, file layout, server-side pruning, and network conditions can all
+change these results. For large reads, `to_arrow_stream()` or
+`to_arrow_reader()` keeps the result lazy instead of holding the complete data
+frame in memory.
+
 ## Query with DuckDB
 
 DuckDB accepts both Arrow materializers:


### PR DESCRIPTION
## Summary

- add high-level end-to-end snapshot performance figures to the README
- report 10K, 1M, and 10M-row eager reads without comparing connectors
- document consumer hardware, measured network conditions, methodology, observed ranges, and materialized R sizes
- explain that the sizes are not wire bytes and point large reads to the lazy Arrow interfaces

No profile, endpoint, catalog, share, or table identity is included.

## Results

| Rows | Materialized R size | Median elapsed |
|---:|---:|---:|
| 10,000 | 0.38 MiB | 5.83 s |
| 1,000,000 | 38.15 MiB | 11.91 s |
| 10,000,000 | 381.47 MiB | 71.49 s |

## Checks

- three live repetitions per size after a warm-up read
- row counts and six-column result shape verified
- full pkgdown site rendered successfully with the performance table
- git diff check and managed secret scan passed