### PR TITLE
Tighten native lifecycle checks

### DIFF
--- a/.github/workflows/package-check.yaml
+++ b/.github/workflows/package-check.yaml
@@ -50,11 +50,19 @@ jobs:
           cargo clippy
           --manifest-path src/rust/Cargo.toml
           --workspace
-          --lib
+          --all-targets
           --all-features
           --locked
           --
           -D warnings
+
+      - name: Run Rust tests
+        run: >-
+          cargo test
+          --manifest-path src/rust/Cargo.toml
+          --workspace
+          --all-features
+          --locked
 
       - name: Install minimum supported Rust
         run: rustup toolchain install 1.88.0 --profile minimal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # delta.sharing <img src="https://user-images.githubusercontent.com/1446829/144671151-b095e1b9-2d24-4d3b-b3c6-a7041e491077.png" align="right" width="140" alt="Delta Sharing logo" />
 
 [![R CMD check](https://github.com/zacdav-db/delta-sharing-r/actions/workflows/package-check.yaml/badge.svg)](https://github.com/zacdav-db/delta-sharing-r/actions/workflows/package-check.yaml)
-[![Codecov](https://codecov.io/gh/zacdav-db/delta-sharing-r/branch/main/graph/badge.svg)](https://app.codecov.io/gh/zacdav-db/delta-sharing-r)
+[![R coverage](https://codecov.io/gh/zacdav-db/delta-sharing-r/branch/main/graph/badge.svg)](https://app.codecov.io/gh/zacdav-db/delta-sharing-r)
 
 An R client for [Delta Sharing](https://delta.io/sharing/), backed by
 [Delta Kernel](https://docs.delta.io/kernel/rust/introduction.html) and Arrow.

--- a/src/rust/src/kernel/adapter.rs
+++ b/src/rust/src/kernel/adapter.rs
@@ -509,3 +509,102 @@ impl RecordBatchReader for KernelRecordBatchReader {
         self.schema.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use arrow_array::Int64Array;
+
+    use super::*;
+
+    fn fixture_table(name: &str) -> String {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/testthat/fixtures/delta")
+            .join(name);
+        std::fs::canonicalize(path)
+            .expect("committed Delta fixture must exist")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn pinned_kernel_default_engine_constructs() {
+        let store = Arc::new(delta_kernel::object_store::memory::InMemory::new());
+        let _engine = DefaultEngineBuilder::new(store).build();
+        let _snapshot_builder = Snapshot::builder_for("memory:///delta-sharing-r-smoke");
+    }
+
+    #[test]
+    fn read_options_reject_non_local_or_ambiguous_inputs() {
+        for location in ["", "relative/table", "https://example.com/table"] {
+            assert!(SnapshotReadOptions::try_new(location.to_string(), None, None, 1_024).is_err());
+        }
+        assert!(SnapshotReadOptions::try_new(
+            "/tmp/table".to_string(),
+            Some(vec!["id".to_string(), "ID".to_string()]),
+            None,
+            1_024,
+        )
+        .is_err());
+        assert!(CdfReadOptions::try_new("/tmp/table".to_string(), None, 2, 1, 1_024,).is_err());
+    }
+
+    #[test]
+    fn snapshot_reader_preserves_projection_limit_and_batch_size() {
+        let options = SnapshotReadOptions::try_new(
+            fixture_table("local-table"),
+            Some(vec!["group".to_string(), "id".to_string()]),
+            Some(5),
+            2,
+        )
+        .unwrap();
+        let reader = snapshot_reader(options).unwrap();
+        assert_eq!(reader.schema().field(0).name(), "group");
+        assert_eq!(reader.schema().field(1).name(), "id");
+
+        let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 5);
+        assert!(batches.iter().all(|batch| batch.num_rows() <= 2));
+    }
+
+    #[test]
+    fn cdf_reader_uses_inclusive_version_bounds() {
+        let options = CdfReadOptions::try_new(
+            fixture_table("cdf"),
+            Some(vec![
+                "id".to_string(),
+                "_change_type".to_string(),
+                "_commit_version".to_string(),
+            ]),
+            1,
+            2,
+            2,
+        )
+        .unwrap();
+        let reader = cdf_reader(options).unwrap();
+        let names = reader
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| field.name().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["id", "_change_type", "_commit_version"]);
+
+        let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+        assert!(batches.iter().all(|batch| batch.num_rows() <= 2));
+        let versions = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(2)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect::<Vec<_>>();
+        assert!(versions.contains(&1));
+        assert!(versions.contains(&2));
+        assert!(versions.iter().all(|version| (1..=2).contains(version)));
+    }
+}

--- a/src/rust/src/stream/mod.rs
+++ b/src/rust/src/stream/mod.rs
@@ -2,14 +2,13 @@
 //!
 //! nanoarrow owns the outer `FFI_ArrowArrayStream` allocation. Rust moves an
 //! initialized stream into that allocation. The release callback drops the
-//! reader, cancellation state, and all resources tied to the active stream.
+//! reader and all resources tied to the active stream.
 
 use std::any::Any;
 use std::hash::{Hash, Hasher};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::ptr::NonNull;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use arrow_array::builder::{Int32Builder, ListBuilder};
@@ -21,98 +20,27 @@ use arrow_array::{
 use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef, TimeUnit};
 use same_file::Handle;
 
-static GLOBAL_METRICS: LazyLock<Arc<StreamMetrics>> =
-    LazyLock::new(|| Arc::new(StreamMetrics::default()));
 static PENDING_CLEANUPS: LazyLock<Mutex<Vec<PendingCleanup>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 
-#[derive(Debug, Default)]
-struct StreamMetrics {
-    active_streams: AtomicU64,
-    cancelled_streams: AtomicU64,
-    emitted_batches: AtomicU64,
-}
-
-#[cfg(test)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct StreamMetricsSnapshot {
-    pub(crate) active_streams: u64,
-    pub(crate) cancelled_streams: u64,
-    pub(crate) emitted_batches: u64,
-}
-
-impl StreamMetrics {
-    #[cfg(test)]
-    fn snapshot(&self) -> StreamMetricsSnapshot {
-        StreamMetricsSnapshot {
-            active_streams: self.active_streams.load(Ordering::Acquire),
-            cancelled_streams: self.cancelled_streams.load(Ordering::Acquire),
-            emitted_batches: self.emitted_batches.load(Ordering::Acquire),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub(crate) struct CancellationToken {
-    cancelled: Arc<AtomicBool>,
-}
-
-impl CancellationToken {
-    fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Release);
-    }
-
-    fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::Acquire)
-    }
-}
-
 /// Resources whose lifetime must exactly match the stream lifetime.
 pub(crate) struct StreamOwner {
-    cancellation: CancellationToken,
-    metrics: Arc<StreamMetrics>,
-    _resources: Vec<Box<dyn Any + Send>>,
-    released: bool,
+    resources: Vec<Box<dyn Any + Send>>,
 }
 
 impl StreamOwner {
-    fn new(metrics: Arc<StreamMetrics>) -> Self {
-        metrics.active_streams.fetch_add(1, Ordering::AcqRel);
+    fn new() -> Self {
         Self {
-            cancellation: CancellationToken::default(),
-            metrics,
-            _resources: Vec::new(),
-            released: false,
+            resources: Vec::new(),
         }
     }
 
     fn keep_alive<T: Any + Send>(&mut self, resource: T) {
-        self._resources.push(Box::new(resource));
-    }
-
-    fn release(&mut self) {
-        if self.released {
-            return;
-        }
-
-        self.cancellation.cancel();
-        self.metrics
-            .cancelled_streams
-            .fetch_add(1, Ordering::AcqRel);
-        self.metrics.active_streams.fetch_sub(1, Ordering::AcqRel);
-        self.released = true;
+        self.resources.push(Box::new(resource));
     }
 
     fn finish(&mut self) {
-        self.release();
-        self._resources.clear();
-    }
-}
-
-impl Drop for StreamOwner {
-    fn drop(&mut self) {
-        // Cancellation happens before retained resources are dropped.
-        self.release();
+        self.resources.clear();
     }
 }
 
@@ -152,23 +80,10 @@ impl Iterator for PanicBoundaryReader {
             return None;
         }
 
-        if self.owner.cancellation.is_cancelled() {
-            self.terminal = true;
-            return Some(Err(ArrowError::ComputeError(
-                "delta-sharing stream cancelled".to_string(),
-            )));
-        }
-
         match catch_unwind(AssertUnwindSafe(|| {
             self.inner.as_mut().and_then(|reader| reader.next())
         })) {
-            Ok(Some(Ok(batch))) => {
-                self.owner
-                    .metrics
-                    .emitted_batches
-                    .fetch_add(1, Ordering::AcqRel);
-                Some(Ok(batch))
-            }
+            Ok(Some(Ok(batch))) => Some(Ok(batch)),
             Ok(Some(Err(error))) => {
                 self.finish();
                 let message = error.to_string();
@@ -201,7 +116,7 @@ impl RecordBatchReader for PanicBoundaryReader {
 impl Drop for PanicBoundaryReader {
     fn drop(&mut self) {
         drop(self.inner.take());
-        self.owner.release();
+        self.owner.finish();
     }
 }
 
@@ -215,14 +130,14 @@ fn export_reader(
 pub(crate) fn record_batch_stream(
     reader: Box<dyn RecordBatchReader + Send>,
 ) -> FFI_ArrowArrayStream {
-    export_reader(reader, StreamOwner::new(GLOBAL_METRICS.clone()))
+    export_reader(reader, StreamOwner::new())
 }
 
 pub(crate) fn record_batch_stream_with_resource<T: Any + Send>(
     reader: Box<dyn RecordBatchReader + Send>,
     resource: T,
 ) -> FFI_ArrowArrayStream {
-    let mut owner = StreamOwner::new(GLOBAL_METRICS.clone());
+    let mut owner = StreamOwner::new();
     owner.keep_alive(resource);
     export_reader(reader, owner)
 }
@@ -870,4 +785,244 @@ fn make_fixture_batch(
             Arc::new(values) as ArrayRef,
         ],
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use arrow_array::ffi_stream::ArrowArrayStreamReader;
+
+    use super::*;
+
+    fn config(batches: i32, error_after: i32, panic_after: i32) -> FixtureStreamConfig {
+        FixtureStreamConfig::try_from_raw(batches, 3, error_after, panic_after).unwrap()
+    }
+
+    fn prepared_root(label: &str) -> (PathBuf, PathBuf) {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            ".delta-sharing-snapshot-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        populate_prepared_root(&root);
+        let root = fs::canonicalize(root).unwrap();
+        let table = root.join("table");
+        (root, table)
+    }
+
+    fn populate_prepared_root(root: &Path) {
+        let log = root.join("table/_delta_log");
+        fs::create_dir_all(&log).unwrap();
+        fs::write(
+            root.join(".delta-sharing-r-prepared-log"),
+            "delta-sharing-r:vnext\n",
+        )
+        .unwrap();
+        fs::write(log.join("00000000000000000000.json"), "{}\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(root, fs::Permissions::from_mode(0o700)).unwrap();
+        }
+    }
+
+    fn prepared_cdf_root(label: &str, end_version: u64) -> (PathBuf, PathBuf) {
+        let (root, table) = prepared_root(label);
+        let log = table.join("_delta_log");
+        fs::remove_file(log.join("00000000000000000000.json")).unwrap();
+        for version in 0..=end_version {
+            fs::write(log.join(format!("{version:020}.json")), "{}\n").unwrap();
+        }
+        (root, table)
+    }
+
+    #[test]
+    fn empty_one_and_many_batches_round_trip() {
+        for expected_batches in [0, 1, 4] {
+            let stream = fixture_stream(config(expected_batches, -1, -1)).unwrap();
+            let reader = ArrowArrayStreamReader::try_new(stream).unwrap();
+            let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+
+            assert_eq!(batches.len(), expected_batches as usize);
+            assert!(batches.iter().all(|batch| batch.num_rows() == 3));
+        }
+    }
+
+    #[test]
+    fn reader_errors_and_panics_are_terminal_and_sanitized() {
+        let stream = fixture_stream(config(3, 1, -1)).unwrap();
+        let mut reader = ArrowArrayStreamReader::try_new(stream).unwrap();
+        assert_eq!(reader.next().unwrap().unwrap().num_rows(), 3);
+        let error = reader.next().unwrap().unwrap_err().to_string();
+        assert!(error.contains("synthetic reader error after 1 batches"));
+        assert!(reader.next().is_none());
+
+        let stream = fixture_stream(config(3, -1, 0)).unwrap();
+        let mut reader = ArrowArrayStreamReader::try_new(stream).unwrap();
+        let error = reader.next().unwrap().unwrap_err().to_string();
+        assert!(error.contains("panic contained at Arrow stream boundary"));
+        assert!(!error.contains("synthetic reader panic"));
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn early_release_drops_owned_resources_once() {
+        struct DropProbe(Arc<AtomicUsize>);
+        impl Drop for DropProbe {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::AcqRel);
+            }
+        }
+
+        let drops = Arc::new(AtomicUsize::new(0));
+        let stream = record_batch_stream_with_resource(
+            Box::new(FixtureReader::new(config(4, -1, -1))),
+            DropProbe(drops.clone()),
+        );
+        let mut reader = ArrowArrayStreamReader::try_new(stream).unwrap();
+        assert_eq!(reader.next().unwrap().unwrap().num_rows(), 3);
+        drop(reader);
+        assert_eq!(drops.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn emitted_array_buffers_outlive_stream_release() {
+        let mut stream = fixture_stream(config(2, -1, -1)).unwrap();
+        let mut array = arrow_array::ffi::FFI_ArrowArray::empty();
+        let get_next = stream.get_next.unwrap();
+        assert_eq!(unsafe { get_next(&mut stream, &mut array) }, 0);
+
+        let release = stream.release.unwrap();
+        unsafe { release(&mut stream) };
+
+        let data_type = DataType::Struct(fixture_schema().fields().clone());
+        let data = unsafe { arrow_array::ffi::from_ffi_and_data_type(array, data_type) }.unwrap();
+        assert_eq!(data.len(), 3);
+    }
+
+    #[test]
+    fn populate_stream_rejects_reuse_and_contains_panics() {
+        let mut initialized = fixture_stream(config(1, -1, -1)).unwrap();
+        let destination = NonNull::from(&mut initialized);
+        assert!(populate_stream(destination, || unreachable!())
+            .unwrap_err()
+            .contains("already initialized"));
+
+        let mut empty = FFI_ArrowArrayStream::empty();
+        let destination = NonNull::from(&mut empty);
+        let error = populate_stream(destination, || panic!("constructor panic must-not-escape"))
+            .unwrap_err();
+        assert!(error.contains("panic contained while creating Arrow stream"));
+        assert!(!error.contains("must-not-escape"));
+        assert!(empty.release.is_none());
+    }
+
+    #[test]
+    fn prepared_log_cleanup_requires_exact_shape_and_revalidates_it() {
+        let (root, table) = prepared_root("valid");
+        let cleanup =
+            PreparedLogCleanup::try_new(root.to_str().unwrap(), table.to_str().unwrap()).unwrap();
+        drop(cleanup);
+        assert!(!root.exists());
+
+        let (root, table) = prepared_root("mutated");
+        let cleanup =
+            PreparedLogCleanup::try_new(root.to_str().unwrap(), table.to_str().unwrap()).unwrap();
+        let unexpected = root.join("unexpected-user-content");
+        fs::write(&unexpected, "must survive fail-closed cleanup").unwrap();
+        drop(cleanup);
+        assert!(unexpected.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn prepared_cdf_cleanup_enumerates_the_full_log_once() {
+        const END_VERSION: u64 = 127;
+
+        let (root, table) = prepared_cdf_root("cdf-linear", END_VERSION);
+        let cleanup = PreparedLogCleanup::try_new_cdf(
+            root.to_str().unwrap(),
+            table.to_str().unwrap(),
+            0,
+            END_VERSION,
+        )
+        .unwrap();
+        let full_log_shape_checks = cleanup.full_log_shape_checks_controller();
+        drop(cleanup);
+
+        assert!(!root.exists());
+        assert_eq!(full_log_shape_checks.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn pending_cleanup_reaper_recovers_after_transient_failures() {
+        let (root, table) = prepared_root("retry");
+        let cleanup =
+            PreparedLogCleanup::try_new(root.to_str().unwrap(), table.to_str().unwrap()).unwrap();
+        let failures = cleanup.injected_failure_controller();
+        cleanup.inject_removal_failures(1_000);
+
+        drop(cleanup);
+        assert!(root.exists());
+        assert!(pending_cleanup_count() > 0);
+
+        failures.store(0, Ordering::Release);
+        reap_pending_cleanups();
+        assert!(!root.exists());
+        assert_eq!(pending_cleanup_count(), 0);
+    }
+
+    #[test]
+    fn terminalization_drops_reader_before_owned_resources() {
+        struct ReaderDropProbe(Arc<AtomicBool>);
+        impl Iterator for ReaderDropProbe {
+            type Item = Result<RecordBatch, ArrowError>;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                None
+            }
+        }
+        impl RecordBatchReader for ReaderDropProbe {
+            fn schema(&self) -> SchemaRef {
+                fixture_schema()
+            }
+        }
+        impl Drop for ReaderDropProbe {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+
+        struct CleanupOrderProbe {
+            reader_dropped: Arc<AtomicBool>,
+            cleanup_dropped: Arc<AtomicBool>,
+        }
+        impl Drop for CleanupOrderProbe {
+            fn drop(&mut self) {
+                assert!(self.reader_dropped.load(Ordering::Acquire));
+                self.cleanup_dropped.store(true, Ordering::Release);
+            }
+        }
+
+        let reader_dropped = Arc::new(AtomicBool::new(false));
+        let cleanup_dropped = Arc::new(AtomicBool::new(false));
+        let stream = record_batch_stream_with_resource(
+            Box::new(ReaderDropProbe(reader_dropped.clone())),
+            CleanupOrderProbe {
+                reader_dropped: reader_dropped.clone(),
+                cleanup_dropped: cleanup_dropped.clone(),
+            },
+        );
+        let mut reader = ArrowArrayStreamReader::try_new(stream).unwrap();
+        assert!(reader.next().is_none());
+        assert!(reader_dropped.load(Ordering::Acquire));
+        assert!(cleanup_dropped.load(Ordering::Acquire));
+    }
 }

--- a/tools/coverage.R
+++ b/tools/coverage.R
@@ -1,8 +1,8 @@
 coverage_dir <- fs::path("coverage")
 fs::dir_create(coverage_dir)
 
-# Native lifecycle behavior is covered by the package check and Rust jobs.
-# This report measures the R implementation exercised by the public test suite.
+# This report measures R line coverage only. Native behavior is exercised by
+# package checks and focused Rust tests, but is outside covr's report.
 reviewed_exclusions <- list(
   "src/native.c" = seq_along(readLines("src/native.c")),
   "R/zzz.R" = seq_along(readLines("R/zzz.R"))


### PR DESCRIPTION
## Summary

- remove unreachable stream metrics and pseudo-cancellation state from the Arrow stream hot path
- add focused Rust tests for Kernel snapshot/CDF reads, Arrow lifetime, panic boundaries, early release, and prepared-log cleanup
- lint all Rust targets and run the Rust test suite in the existing package-check workflow
- identify Codecov explicitly as R coverage

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked` (13 passed)
- `cargo +1.88.0 check --workspace --lib --all-features --locked`
- clean `R CMD INSTALL --preclean`
- complete installed-package testthat suite