### PR TITLE
Simplify query and native read paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Suggests:
   arrow,
   DBI,
   duckdb,
-  httpuv,
   knitr,
   rmarkdown,
   testthat (>= 3.0.0),

--- a/R/client.R
+++ b/R/client.R
@@ -1,10 +1,7 @@
-# Remove embedded user information before displaying an endpoint. For example,
-# `https://user:secret@example.com/api` becomes `https://example.com/api`.
-redact_url_userinfo <- function(url) {
-  if (!is.character(url) || length(url) != 1L || is.na(url)) {
-    return("<invalid endpoint>")
-  }
-  sub("^([^:/?#]+://)[^/@]*@", "\\1", url)
+# Remove credentials, query parameters, and fragments from a printed endpoint.
+redact_endpoint <- function(endpoint) {
+  endpoint <- sub("^([^:/?#]+://)[^/@]*@", "\\1", endpoint)
+  sub("[?#].*$", "", endpoint)
 }
 
 #' Create a Delta Sharing client
@@ -94,7 +91,7 @@ SharingClient <- R6::R6Class(
     print = function(...) {
       cat(sprintf(
         "<SharingClient> %s [%s]\n",
-        redact_url_userinfo(private$profile$endpoint),
+        redact_endpoint(private$profile$endpoint),
         private$profile$auth_type
       ))
       invisible(self)

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -16,8 +16,9 @@ condition_classes <- list(
 #'
 #' Package-specific errors inherit from `delta_sharing_error`. More specific
 #' subclasses identify validation, authentication, protocol, kernel,
-#' unsupported-feature, and cancellation failures. HTTP requests retain
-#' [httr2::req_perform()]'s native condition classes and provider messages.
+#' unsupported-feature, and cancellation failures. HTTP requests and Arrow
+#' consumers retain their native condition classes and messages. User
+#' interrupts are reported as cancellation failures.
 #'
 #' @name delta_sharing_conditions
 #' @keywords internal

--- a/R/kernel-log.R
+++ b/R/kernel-log.R
@@ -140,8 +140,10 @@ prepare_synthetic_log <- function(lines) {
   })
 }
 
-# Write a commit header followed by the bytes in one bounded action stage.
-write_staged_commit <- function(commit, header, staged_actions) {
+# Write a snapshot commit from its header and bounded action stage. The stage
+# is copied in chunks, then removed before ownership transfers to Rust.
+write_snapshot_commit <- function(log_dir, header, staged_actions) {
+  commit <- fs::path(log_dir, log_commit_name)
   local({
     output <- file(commit, open = "wb")
     on.exit(close(output), add = TRUE)
@@ -157,15 +159,6 @@ write_staged_commit <- function(commit, header, staged_actions) {
       writeBin(bytes, output)
     }
   })
-  invisible(commit)
-}
-
-# Publish a snapshot commit from a bounded action staging file. The staging
-# file lives inside the private log root and is removed before native ownership
-# validation, leaving exactly the one commit expected by the cleanup guard.
-write_staged_snapshot_commit <- function(log_dir, header, staged_actions) {
-  commit <- fs::path(log_dir, log_commit_name)
-  write_staged_commit(commit, header, staged_actions)
   fs::file_delete(staged_actions)
   invisible(commit)
 }

--- a/R/native-bridge.R
+++ b/R/native-bridge.R
@@ -74,24 +74,6 @@ cdf_whole_version <- function(value, label) {
   as.double(value)
 }
 
-native_test_stream <- function(
-  batches = 1L,
-  rows_per_batch = 3L,
-  error_after = -1L,
-  panic_after = -1L
-) {
-  stream <- nanoarrow::nanoarrow_allocate_array_stream()
-  .Call(
-    C_delta_sharing_stream_from_test_data,
-    stream,
-    as.integer(batches),
-    as.integer(rows_per_batch),
-    as.integer(error_after),
-    as.integer(panic_after)
-  )
-  interruptible_native_stream(stream)
-}
-
 native_stream_interrupt_message <- "delta-sharing stream interrupted"
 
 native_stream_was_interrupted <- function(condition) {

--- a/R/native-bridge.R
+++ b/R/native-bridge.R
@@ -111,41 +111,17 @@ abort_native_stream_interrupt <- function(operation) {
   )
 }
 
-abort_native_stream_failure <- function(operation) {
-  abort(
-    "Delta Kernel could not produce the requested Arrow data.",
-    type = "kernel",
-    operation = operation,
-    kernel_category = "data_scan"
-  )
-}
-
 with_native_stream_conditions <- function(code, operation, stream = NULL) {
   tryCatch(
     code,
     error = function(condition) {
-      if (inherits(condition, "delta_sharing_error")) {
-        if (!is.null(stream)) {
-          release_materializer_stream(stream)
-        }
-        stop(condition)
+      if (!is.null(stream)) {
+        release_materializer_stream(stream)
       }
       if (native_stream_was_interrupted(condition)) {
-        if (!is.null(stream)) {
-          release_materializer_stream(stream)
-        }
         abort_native_stream_interrupt(operation)
       }
-      if (is.null(stream)) {
-        stop(condition)
-      }
-      # At this point a live stream has entered its consumer. Hook-shape
-      # validation and Arrow reader construction happen before this guard;
-      # production code inside it only performs schema and data pulls.
-      # Injected internal consumer hooks intentionally share this public
-      # redaction boundary so their implementation detail cannot escape.
-      release_materializer_stream(stream)
-      abort_native_stream_failure(operation)
+      stop(condition)
     },
     interrupt = function(condition) {
       if (!is.null(stream)) {

--- a/R/read-execution.R
+++ b/R/read-execution.R
@@ -115,7 +115,7 @@ prepare_snapshot_query_log <- function(
       query_result$metadata,
       "read"
     )
-    write_staged_snapshot_commit(log_dir, header, staged_actions)
+    write_snapshot_commit(log_dir, header, staged_actions)
     list(
       response_format = format,
       page_count = query_result$page_count,

--- a/R/read-execution.R
+++ b/R/read-execution.R
@@ -4,14 +4,6 @@
 # the local path to the native kernel scan. Cleanup of the temp log is
 # transferred to the native stream once it is constructed.
 
-# The query endpoints require a single response format, unlike /metadata.
-query_capabilities <- function(format, for_cdf = FALSE) {
-  paste0(
-    capability_header(format, for_cdf = for_cdf),
-    ";includeendstreamaction=true"
-  )
-}
-
 # Fetch Query Table pages and append their file actions to one staging file.
 # Each response page is buffered by httr2, matching its ordinary request path.
 write_snapshot_query_pages <- function(
@@ -38,11 +30,12 @@ write_snapshot_query_pages <- function(
     )
     req <- httr2::req_headers(
       req,
-      `delta-sharing-capabilities` = query_capabilities(format)
+      `delta-sharing-capabilities` = capability_header(format)
     )
     req <- httr2::req_body_json(req, query_body(spec, page_token))
     resp <- httr2::req_perform(req)
     actions <- parse_ndjson_lines(httr2::resp_body_string(resp), "read")
+    next_page_token <- find_next_page_token(actions, "read")
     page <- purrr::reduce(
       actions,
       function(state, action) {
@@ -51,15 +44,11 @@ write_snapshot_query_pages <- function(
         } else if (!is.null(action$metaData)) {
           state$metadata <- action$metaData
         }
-        if (is_scalar_character(action$nextPageToken)) {
-          state$next_page_token <- action$nextPageToken
-        }
         state
       },
       .init = list(
         protocol = protocol,
-        metadata = metadata,
-        next_page_token = NULL
+        metadata = metadata
       )
     )
 
@@ -74,7 +63,7 @@ write_snapshot_query_pages <- function(
 
     protocol <- page$protocol
     metadata <- page$metadata
-    page_token <- page$next_page_token
+    page_token <- next_page_token
     file_count <- file_count + length(files)
     if (is.null(page_token)) {
       break
@@ -160,7 +149,7 @@ changes_query <- function(spec, page_token) {
 # effective bounds come from the versions represented in the response, as in
 # the Python Kernel reader.
 sharing_query_changes <- function(profile, auth, identifier, spec) {
-  actions <- list()
+  pages <- list()
   page_token <- NULL
   repeat {
     req <- sharing_request(
@@ -172,48 +161,55 @@ sharing_query_changes <- function(profile, auth, identifier, spec) {
     )
     req <- httr2::req_headers(
       req,
-      `delta-sharing-capabilities` = query_capabilities(
+      `delta-sharing-capabilities` = capability_header(
         "delta",
         for_cdf = TRUE
       )
     )
     resp <- httr2::req_perform(req)
     page_actions <- parse_ndjson_lines(httr2::resp_body_string(resp), "changes")
-    actions <- c(actions, page_actions)
-    page_token <- find_next_page_token(page_actions)
+    pages[[length(pages) + 1L]] <- page_actions
+    page_token <- find_next_page_token(page_actions, "changes")
     if (is.null(page_token)) {
       break
     }
   }
   bucket_cdf_actions(
-    actions,
+    purrr::list_c(pages),
     spec$starting_version,
     spec$ending_version
   )
 }
 
-find_next_page_token <- function(actions) {
+# EndStreamAction is optional, but servers use it for pagination and failures.
+find_next_page_token <- function(actions, operation) {
   action <- purrr::detect(actions, function(action) {
-    token <- action$nextPageToken
-    is_scalar_character(token)
+    !is.null(action$endStreamAction)
   })
-  action$nextPageToken
+  terminal <- action$endStreamAction
+  if (!is.null(terminal$errorMessage)) {
+    abort(
+      "The server ended the query with an error: {terminal$errorMessage}",
+      type = "protocol",
+      operation = operation,
+      status_code = terminal$httpStatusErrorCode
+    )
+  }
+  token <- terminal$nextPageToken
+  if (is_scalar_character(token)) token else NULL
 }
 
 bucket_cdf_actions <- function(actions, start_version, end_version) {
-  protocol <- NULL
-  by_version <- list() # keyed by as.character(version)
-  new_version <- function(version) {
-    list(
-      version = version,
-      timestamp_ms = NA_real_,
-      actions = list()
-    )
-  }
-  for (action in actions) {
-    if (!is.null(action$protocol)) {
-      protocol <- action$protocol$deltaProtocol %||% action$protocol
-    } else if (!is.null(action$metaData)) {
+  protocol_action <- purrr::detect(
+    rev(actions),
+    function(action) !is.null(action$protocol)
+  )
+  protocol <- protocol_action$protocol$deltaProtocol %||%
+    protocol_action$protocol
+
+  # Normalize and group once rather than repeatedly growing each version list.
+  entries <- purrr::map(actions, function(action) {
+    if (!is.null(action$metaData)) {
       # Metadata applies at the start of the range when the server omits a
       # version (as Databricks does).
       v <- action$metaData$version
@@ -227,27 +223,39 @@ bucket_cdf_actions <- function(actions, start_version, end_version) {
         }
         v <- start_version
       }
-      key <- as.character(v)
-      version_data <- by_version[[key]] %||% new_version(v)
-      version_data$actions <- c(
-        version_data$actions,
-        list(list(
+      return(list(
+        version = v,
+        action = list(
           metaData = action$metaData$deltaMetadata %||% action$metaData
-        ))
-      )
-      by_version[[key]] <- version_data
-    } else if (!is.null(action$file)) {
-      f <- action$file
-      key <- as.character(f$version)
-      version_data <- by_version[[key]] %||% new_version(f$version)
-      version_data$timestamp_ms <- f$timestamp
-      version_data$actions <- c(
-        version_data$actions,
-        list(f$deltaSingleAction)
-      )
-      by_version[[key]] <- version_data
+        )
+      ))
     }
-  }
+    if (!is.null(action$file)) {
+      f <- action$file
+      return(list(
+        version = f$version,
+        timestamp_ms = f$timestamp,
+        action = f$deltaSingleAction
+      ))
+    }
+    NULL
+  })
+  entries <- purrr::compact(entries)
+  by_version <- split(
+    entries,
+    purrr::map_chr(entries, function(entry) as.character(entry$version))
+  )
+  by_version <- purrr::map(by_version, function(entries) {
+    last_file <- purrr::detect(
+      rev(entries),
+      function(entry) !is.null(entry$timestamp_ms)
+    )
+    list(
+      version = entries[[1L]]$version,
+      timestamp_ms = last_file$timestamp_ms %||% NA_real_,
+      actions = purrr::map(entries, "action")
+    )
+  })
   if (is.null(protocol)) {
     abort(
       "The change data feed response did not include a protocol.",

--- a/R/read-execution.R
+++ b/R/read-execution.R
@@ -305,7 +305,8 @@ query_body <- function(spec, page_token) {
   if (!is.null(spec$limit)) body$limitHint <- spec$limit
   if (!is.null(spec$version)) {
     body$version <- spec$version
-  } else if (!is.null(spec$timestamp)) {
+  }
+  if (!is.null(spec$timestamp)) {
     body$timestamp <- format_timestamp(spec$timestamp)
   }
   if (!is.null(page_token)) body$pageToken <- page_token

--- a/R/table-metadata.R
+++ b/R/table-metadata.R
@@ -212,6 +212,13 @@ parse_table_actions <- function(resp, operation) {
       )
     }
   }
+  if (is.null(protocol) || is.null(metadata)) {
+    abort(
+      "The metadata response did not include protocol and metadata.",
+      type = "protocol",
+      operation = operation
+    )
+  }
   list(
     protocol = protocol,
     metadata = metadata,

--- a/R/table-metadata.R
+++ b/R/table-metadata.R
@@ -119,12 +119,18 @@ parse_version_header <- function(resp, operation) {
   value
 }
 
-# Split an NDJSON body into parsed JSON objects (one per non-empty line).
+# Parse one buffered NDJSON page as a JSON array, ignoring empty lines.
 parse_ndjson_lines <- function(text, operation) {
-  lines <- purrr::list_c(strsplit(text, "\n", fixed = TRUE))
+  lines <- strsplit(text, "\n", fixed = TRUE)[[1L]]
   lines <- lines[nzchar(trimws(lines))]
+  if (length(lines) == 0L) {
+    return(list())
+  }
   parsed <- tryCatch(
-    purrr::map(lines, jsonlite::fromJSON, simplifyVector = FALSE),
+    jsonlite::fromJSON(
+      paste0("[", paste(lines, collapse = ","), "]"),
+      simplifyVector = FALSE
+    ),
     error = function(cnd) {
       abort(
         "The server returned an invalid metadata line.",

--- a/inst/dependency-licenses/dependency-inventory.json
+++ b/inst/dependency-licenses/dependency-inventory.json
@@ -105,13 +105,6 @@
     {
       "distribution": "external R package; code is not bundled",
       "license_authority": "the installed dependency's DESCRIPTION License field and license files",
-      "name": "httpuv",
-      "relationship": "Suggests",
-      "requirement": null
-    },
-    {
-      "distribution": "external R package; code is not bundled",
-      "license_authority": "the installed dependency's DESCRIPTION License field and license files",
       "name": "knitr",
       "relationship": "Suggests",
       "requirement": null

--- a/man/delta_sharing_conditions.Rd
+++ b/man/delta_sharing_conditions.Rd
@@ -6,7 +6,8 @@
 \description{
 Package-specific errors inherit from \code{delta_sharing_error}. More specific
 subclasses identify validation, authentication, protocol, kernel,
-unsupported-feature, and cancellation failures. HTTP requests retain
-\code{\link[httr2:req_perform]{httr2::req_perform()}}'s native condition classes and provider messages.
+unsupported-feature, and cancellation failures. HTTP requests and Arrow
+consumers retain their native condition classes and messages. User
+interrupts are reported as cancellation failures.
 }
 \keyword{internal}

--- a/src/native.c
+++ b/src/native.c
@@ -36,6 +36,19 @@ struct ArrowArrayStream {
   void *private_data;
 };
 
+typedef struct {
+  const char **values;
+  size_t count;
+} DeltaSharingColumns;
+
+typedef struct {
+  ArrowArrayStream *stream;
+  const char *table_location;
+  const char *cleanup_root;
+  DeltaSharingColumns columns;
+  uint32_t batch_size;
+} DeltaSharingReadArguments;
+
 #ifdef _WIN32
 typedef DWORD DeltaSharingThreadId;
 
@@ -218,6 +231,78 @@ static const char *scalar_utf8(SEXP value, const char *name) {
   return result;
 }
 
+static ArrowArrayStream *nanoarrow_stream(SEXP value) {
+  if (TYPEOF(value) != EXTPTRSXP) {
+    Rf_error("`stream_xptr` must be an R external pointer.");
+  }
+  if (!Rf_inherits(value, "nanoarrow_array_stream")) {
+    Rf_error("`stream_xptr` must inherit from 'nanoarrow_array_stream'.");
+  }
+
+  ArrowArrayStream *stream = (ArrowArrayStream *)R_ExternalPtrAddr(value);
+  if (stream == NULL) {
+    Rf_error("nanoarrow stream pointer is NULL.");
+  }
+  return stream;
+}
+
+static uint32_t read_batch_size(SEXP value) {
+  const int32_t batch_size = scalar_int32(value, "batch_size");
+  if (batch_size < 1 || batch_size > 1000000) {
+    Rf_error("`batch_size` must be between 1 and 1000000.");
+  }
+  return (uint32_t)batch_size;
+}
+
+static DeltaSharingColumns read_columns(SEXP value) {
+  DeltaSharingColumns columns = {NULL, 0};
+  if (value == R_NilValue) {
+    return columns;
+  }
+  if (TYPEOF(value) != STRSXP) {
+    Rf_error("`columns` must be NULL or a character vector.");
+  }
+
+  const R_xlen_t count = XLENGTH(value);
+  if (count == 0) {
+    Rf_error("`columns` must be NULL or contain at least one name.");
+  }
+  if ((uintmax_t)count > SIZE_MAX / sizeof(const char *)) {
+    Rf_error("`columns` is too large for this platform.");
+  }
+
+  columns.count = (size_t)count;
+  columns.values =
+      (const char **)R_alloc(columns.count, sizeof(const char *));
+  for (R_xlen_t index = 0; index < count; ++index) {
+    if (STRING_ELT(value, index) == NA_STRING) {
+      Rf_error("`columns` must not contain missing names.");
+    }
+    columns.values[index] = Rf_translateCharUTF8(STRING_ELT(value, index));
+    if (columns.values[index][0] == '\0') {
+      Rf_error("`columns` must not contain empty names.");
+    }
+  }
+  return columns;
+}
+
+static DeltaSharingReadArguments read_arguments(
+    SEXP stream_xptr,
+    SEXP table_location,
+    SEXP cleanup_root,
+    SEXP columns,
+    SEXP batch_size) {
+  DeltaSharingReadArguments arguments;
+  arguments.stream = nanoarrow_stream(stream_xptr);
+  arguments.table_location = scalar_utf8(table_location, "table_location");
+  arguments.cleanup_root = cleanup_root == R_NilValue
+                               ? NULL
+                               : scalar_utf8(cleanup_root, "cleanup_root");
+  arguments.columns = read_columns(columns);
+  arguments.batch_size = read_batch_size(batch_size);
+  return arguments;
+}
+
 static uint64_t optional_limit(SEXP value, int32_t *has_limit) {
   if (value == R_NilValue) {
     *has_limit = 0;
@@ -278,18 +363,7 @@ static SEXP delta_sharing_stream_from_test_data(
     SEXP rows_per_batch,
     SEXP error_after,
     SEXP panic_after) {
-  if (TYPEOF(stream_xptr) != EXTPTRSXP) {
-    Rf_error("`stream_xptr` must be an R external pointer.");
-  }
-  if (!Rf_inherits(stream_xptr, "nanoarrow_array_stream")) {
-    Rf_error("`stream_xptr` must inherit from 'nanoarrow_array_stream'.");
-  }
-
-  ArrowArrayStream *stream =
-      (ArrowArrayStream *)R_ExternalPtrAddr(stream_xptr);
-  if (stream == NULL) {
-    Rf_error("nanoarrow stream pointer is NULL.");
-  }
+  ArrowArrayStream *stream = nanoarrow_stream(stream_xptr);
 
   const int32_t batches_value = scalar_int32(batches, "batches");
   const int32_t rows_value = scalar_int32(rows_per_batch, "rows_per_batch");
@@ -321,77 +395,29 @@ static SEXP delta_sharing_stream_from_snapshot(
     SEXP columns,
     SEXP limit,
     SEXP batch_size) {
-  if (TYPEOF(stream_xptr) != EXTPTRSXP) {
-    Rf_error("`stream_xptr` must be an R external pointer.");
-  }
-  if (!Rf_inherits(stream_xptr, "nanoarrow_array_stream")) {
-    Rf_error("`stream_xptr` must inherit from 'nanoarrow_array_stream'.");
-  }
-
-  ArrowArrayStream *stream =
-      (ArrowArrayStream *)R_ExternalPtrAddr(stream_xptr);
-  if (stream == NULL) {
-    Rf_error("nanoarrow stream pointer is NULL.");
-  }
-
-  const int32_t batch_size_value = scalar_int32(batch_size, "batch_size");
-  if (batch_size_value < 1 || batch_size_value > 1000000) {
-    Rf_error("`batch_size` must be between 1 and 1000000.");
-  }
-
-  if (columns != R_NilValue && TYPEOF(columns) != STRSXP) {
-    Rf_error("`columns` must be NULL or a character vector.");
-  }
-  const R_xlen_t column_count =
-      columns == R_NilValue ? 0 : XLENGTH(columns);
-  if (columns != R_NilValue && column_count == 0) {
-    Rf_error("`columns` must be NULL or contain at least one name.");
-  }
-  if (column_count > 10000) {
-    Rf_error("`columns` must contain at most 10000 names.");
-  }
-
-  const char **column_values = NULL;
-  if (column_count > 0) {
-    column_values =
-        (const char **)R_alloc((size_t)column_count, sizeof(const char *));
-    for (R_xlen_t index = 0; index < column_count; ++index) {
-      if (STRING_ELT(columns, index) == NA_STRING) {
-        Rf_error("`columns` must not contain missing names.");
-      }
-      column_values[index] = Rf_translateCharUTF8(STRING_ELT(columns, index));
-      if (column_values[index][0] == '\0') {
-        Rf_error("`columns` must not contain empty names.");
-      }
-    }
-  }
+  const DeltaSharingReadArguments arguments = read_arguments(
+      stream_xptr, table_location, cleanup_root, columns, batch_size);
 
   int32_t has_limit = 0;
   const uint64_t limit_value = optional_limit(limit, &has_limit);
-  const char *table_location_value =
-      scalar_utf8(table_location, "table_location");
-  const char *cleanup_root_value = NULL;
-  if (cleanup_root != R_NilValue) {
-    cleanup_root_value = scalar_utf8(cleanup_root, "cleanup_root");
-  }
 
   char error[DELTA_SHARING_ERROR_CAPACITY] = {0};
   const int32_t status = delta_sharing_native_populate_snapshot_stream(
-      stream,
-      table_location_value,
-      cleanup_root_value,
-      column_values,
-      (size_t)column_count,
+      arguments.stream,
+      arguments.table_location,
+      arguments.cleanup_root,
+      arguments.columns.values,
+      arguments.columns.count,
       has_limit,
       limit_value,
-      (uint32_t)batch_size_value,
+      arguments.batch_size,
       error,
       sizeof(error));
 
   if (status != 0) {
     raise_native_error(status, error);
   }
-  install_interrupt_wrapper_or_error(stream);
+  install_interrupt_wrapper_or_error(arguments.stream);
 
   return R_NilValue;
 }
@@ -404,54 +430,8 @@ static SEXP delta_sharing_stream_from_cdf(
     SEXP start_version,
     SEXP end_version,
     SEXP batch_size) {
-  if (TYPEOF(stream_xptr) != EXTPTRSXP) {
-    Rf_error("`stream_xptr` must be an R external pointer.");
-  }
-  if (!Rf_inherits(stream_xptr, "nanoarrow_array_stream")) {
-    Rf_error("`stream_xptr` must inherit from 'nanoarrow_array_stream'.");
-  }
-  ArrowArrayStream *stream =
-      (ArrowArrayStream *)R_ExternalPtrAddr(stream_xptr);
-  if (stream == NULL) {
-    Rf_error("nanoarrow stream pointer is NULL.");
-  }
-
-  const int32_t batch_size_value = scalar_int32(batch_size, "batch_size");
-  if (batch_size_value < 1 || batch_size_value > 1000000) {
-    Rf_error("`batch_size` must be between 1 and 1000000.");
-  }
-  if (columns != R_NilValue && TYPEOF(columns) != STRSXP) {
-    Rf_error("`columns` must be NULL or a character vector.");
-  }
-  const R_xlen_t column_count =
-      columns == R_NilValue ? 0 : XLENGTH(columns);
-  if (columns != R_NilValue && column_count == 0) {
-    Rf_error("`columns` must be NULL or contain at least one name.");
-  }
-  if (column_count > 10000) {
-    Rf_error("`columns` must contain at most 10000 names.");
-  }
-  const char **column_values = NULL;
-  if (column_count > 0) {
-    column_values =
-        (const char **)R_alloc((size_t)column_count, sizeof(const char *));
-    for (R_xlen_t index = 0; index < column_count; ++index) {
-      if (STRING_ELT(columns, index) == NA_STRING) {
-        Rf_error("`columns` must not contain missing names.");
-      }
-      column_values[index] = Rf_translateCharUTF8(STRING_ELT(columns, index));
-      if (column_values[index][0] == '\0') {
-        Rf_error("`columns` must not contain empty names.");
-      }
-    }
-  }
-
-  const char *table_location_value =
-      scalar_utf8(table_location, "table_location");
-  const char *cleanup_root_value = NULL;
-  if (cleanup_root != R_NilValue) {
-    cleanup_root_value = scalar_utf8(cleanup_root, "cleanup_root");
-  }
+  const DeltaSharingReadArguments arguments = read_arguments(
+      stream_xptr, table_location, cleanup_root, columns, batch_size);
   const uint64_t start_version_value =
       required_version(start_version, "start_version");
   const uint64_t end_version_value =
@@ -459,20 +439,20 @@ static SEXP delta_sharing_stream_from_cdf(
 
   char error[DELTA_SHARING_ERROR_CAPACITY] = {0};
   const int32_t status = delta_sharing_native_populate_cdf_stream(
-      stream,
-      table_location_value,
-      cleanup_root_value,
-      column_values,
-      (size_t)column_count,
+      arguments.stream,
+      arguments.table_location,
+      arguments.cleanup_root,
+      arguments.columns.values,
+      arguments.columns.count,
       start_version_value,
       end_version_value,
-      (uint32_t)batch_size_value,
+      arguments.batch_size,
       error,
       sizeof(error));
   if (status != 0) {
     raise_native_error(status, error);
   }
-  install_interrupt_wrapper_or_error(stream);
+  install_interrupt_wrapper_or_error(arguments.stream);
   return R_NilValue;
 }
 

--- a/src/native.c
+++ b/src/native.c
@@ -357,37 +357,6 @@ static void raise_native_error(int32_t status, const char *message) {
   Rf_error("Native operation failed (status %d): %s", status, safe_message);
 }
 
-static SEXP delta_sharing_stream_from_test_data(
-    SEXP stream_xptr,
-    SEXP batches,
-    SEXP rows_per_batch,
-    SEXP error_after,
-    SEXP panic_after) {
-  ArrowArrayStream *stream = nanoarrow_stream(stream_xptr);
-
-  const int32_t batches_value = scalar_int32(batches, "batches");
-  const int32_t rows_value = scalar_int32(rows_per_batch, "rows_per_batch");
-  const int32_t error_value = scalar_int32(error_after, "error_after");
-  const int32_t panic_value = scalar_int32(panic_after, "panic_after");
-
-  char error[DELTA_SHARING_ERROR_CAPACITY] = {0};
-  const int32_t status = delta_sharing_native_populate_test_stream(
-      stream,
-      batches_value,
-      rows_value,
-      error_value,
-      panic_value,
-      error,
-      sizeof(error));
-
-  if (status != 0) {
-    raise_native_error(status, error);
-  }
-  install_interrupt_wrapper_or_error(stream);
-
-  return R_NilValue;
-}
-
 static SEXP delta_sharing_stream_from_snapshot(
     SEXP stream_xptr,
     SEXP table_location,
@@ -468,9 +437,6 @@ static SEXP delta_sharing_reap_pending_cleanups(void) {
 }
 
 static const R_CallMethodDef call_methods[] = {
-    {"delta_sharing_stream_from_test_data",
-     (DL_FUNC)&delta_sharing_stream_from_test_data,
-     5},
     {"delta_sharing_stream_from_snapshot",
      (DL_FUNC)&delta_sharing_stream_from_snapshot,
      6},

--- a/src/rust/include/delta_sharing_native.h
+++ b/src/rust/include/delta_sharing_native.h
@@ -6,15 +6,6 @@
 
 typedef struct ArrowArrayStream ArrowArrayStream;
 
-int32_t delta_sharing_native_populate_test_stream(
-    ArrowArrayStream *destination,
-    int32_t batches,
-    int32_t rows_per_batch,
-    int32_t error_after,
-    int32_t panic_after,
-    char *error_buffer,
-    size_t error_capacity);
-
 int32_t delta_sharing_native_populate_snapshot_stream(
     ArrowArrayStream *destination,
     const char *table_location,

--- a/src/rust/src/kernel/adapter.rs
+++ b/src/rust/src/kernel/adapter.rs
@@ -22,8 +22,6 @@ use url::Url;
 const MAX_BATCH_SIZE: usize = 1_000_000;
 const MIN_SOURCE_BATCH_SIZE: usize = 1_000;
 const MAX_SOURCE_BATCH_SIZE: usize = 65_536;
-const MAX_PROJECTION_COLUMNS: usize = 10_000;
-const MAX_TABLE_LOCATION_BYTES: usize = 32_768;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SnapshotReadOptions {
@@ -104,12 +102,6 @@ fn validate_projection(columns: Option<&Vec<String>>) -> Result<(), String> {
     if columns.is_empty() {
         return Err("`columns` must be NULL or contain at least one name".to_string());
     }
-    if columns.len() > MAX_PROJECTION_COLUMNS {
-        return Err(format!(
-            "`columns` must contain at most {MAX_PROJECTION_COLUMNS} names"
-        ));
-    }
-
     let mut seen = HashSet::with_capacity(columns.len());
     for column in columns {
         if column.is_empty() {
@@ -130,11 +122,6 @@ fn validate_projection(columns: Option<&Vec<String>>) -> Result<(), String> {
 fn validate_table_location(table_location: &str) -> Result<(), String> {
     if table_location.is_empty() {
         return Err("`table_location` must not be empty".to_string());
-    }
-    if table_location.len() > MAX_TABLE_LOCATION_BYTES {
-        return Err(format!(
-            "`table_location` must be at most {MAX_TABLE_LOCATION_BYTES} bytes"
-        ));
     }
     if table_location.as_bytes().contains(&0) {
         return Err("`table_location` must not contain NUL bytes".to_string());
@@ -546,6 +533,15 @@ mod tests {
         )
         .is_err());
         assert!(CdfReadOptions::try_new("/tmp/table".to_string(), None, 2, 1, 1_024,).is_err());
+    }
+
+    #[test]
+    fn read_options_do_not_impose_arbitrary_size_limits() {
+        let columns = (0..10_001).map(|i| format!("column_{i}")).collect();
+        assert!(validate_projection(Some(&columns)).is_ok());
+
+        let long_local_path = format!("/{}", "a".repeat(32_768));
+        assert!(validate_table_location(&long_local_path).is_ok());
     }
 
     #[test]

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -134,9 +134,6 @@ pub unsafe extern "C" fn delta_sharing_native_populate_snapshot_stream(
         if table_location.is_null() {
             return Err("`table_location` pointer is NULL".to_string());
         }
-        if column_count > 10_000 {
-            return Err("`column_count` must be at most 10000".to_string());
-        }
         if column_count > 0 && columns.is_null() {
             return Err("`columns` pointer is NULL for a non-empty projection".to_string());
         }
@@ -166,8 +163,8 @@ pub unsafe extern "C" fn delta_sharing_native_populate_snapshot_stream(
         let projected_columns = if column_count == 0 {
             None
         } else {
-            // SAFETY: non-null and length bounds were checked above; the C
-            // shim owns this pointer array throughout the Rust call.
+            // SAFETY: the C shim owns this valid pointer array throughout the
+            // Rust call.
             let raw_columns = unsafe { std::slice::from_raw_parts(columns, column_count) };
             let mut projected = Vec::with_capacity(column_count);
             for (index, column) in raw_columns.iter().copied().enumerate() {
@@ -233,9 +230,6 @@ pub unsafe extern "C" fn delta_sharing_native_populate_cdf_stream(
             .ok_or_else(|| "nanoarrow stream pointer is NULL".to_string())?;
         if table_location.is_null() {
             return Err("`table_location` pointer is NULL".to_string());
-        }
-        if column_count > 10_000 {
-            return Err("`column_count` must be at most 10000".to_string());
         }
         if column_count > 0 && columns.is_null() {
             return Err("`columns` pointer is NULL for a non-empty projection".to_string());

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -20,7 +20,6 @@ use std::ptr::NonNull;
 use arrow_array::ffi_stream::FFI_ArrowArrayStream;
 
 use crate::kernel::adapter::{CdfReadOptions, SnapshotReadOptions};
-use crate::stream::{fixture_stream, FixtureStreamConfig};
 
 const STATUS_OK: c_int = 0;
 const STATUS_ERROR: c_int = 1;
@@ -74,32 +73,6 @@ where
             STATUS_PANIC
         }
     }
-}
-
-/// Populate a nanoarrow-owned ArrowArrayStream with deterministic test data.
-///
-/// # Safety
-///
-/// `destination` must point to writable, aligned storage for an uninitialized
-/// Arrow C Stream owned by nanoarrow. `error_buffer`, when non-null, must point
-/// to `error_capacity` writable bytes.
-#[no_mangle]
-pub unsafe extern "C" fn delta_sharing_native_populate_test_stream(
-    destination: *mut FFI_ArrowArrayStream,
-    batches: i32,
-    rows_per_batch: i32,
-    error_after: i32,
-    panic_after: i32,
-    error_buffer: *mut c_char,
-    error_capacity: usize,
-) -> c_int {
-    ffi_boundary(error_buffer, error_capacity, || {
-        let destination = NonNull::new(destination)
-            .ok_or_else(|| "nanoarrow stream pointer is NULL".to_string())?;
-        let config =
-            FixtureStreamConfig::try_from_raw(batches, rows_per_batch, error_after, panic_after)?;
-        stream::populate_stream(destination, || fixture_stream(config))
-    })
 }
 
 /// Populate a nanoarrow-owned ArrowArrayStream from a prepared local Delta table.

--- a/src/rust/src/stream/mod.rs
+++ b/src/rust/src/stream/mod.rs
@@ -9,15 +9,21 @@ use std::hash::{Hash, Hasher};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::ptr::NonNull;
-use std::sync::{Arc, LazyLock, Mutex};
+#[cfg(test)]
+use std::sync::Arc;
+use std::sync::{LazyLock, Mutex};
 
+#[cfg(test)]
 use arrow_array::builder::{Int32Builder, ListBuilder};
 use arrow_array::ffi_stream::FFI_ArrowArrayStream;
+#[cfg(test)]
 use arrow_array::{
-    ArrayRef, Decimal128Array, Int32Array, Int64Array, RecordBatch, RecordBatchReader, StringArray,
-    TimestampMicrosecondArray,
+    ArrayRef, Decimal128Array, Int32Array, Int64Array, StringArray, TimestampMicrosecondArray,
 };
-use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef, TimeUnit};
+use arrow_array::{RecordBatch, RecordBatchReader};
+use arrow_schema::{ArrowError, SchemaRef};
+#[cfg(test)]
+use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use same_file::Handle;
 
 static PENDING_CLEANUPS: LazyLock<Mutex<Vec<PendingCleanup>>> =
@@ -638,6 +644,7 @@ where
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg(test)]
 pub(crate) struct FixtureStreamConfig {
     batches: usize,
     rows_per_batch: usize,
@@ -645,6 +652,7 @@ pub(crate) struct FixtureStreamConfig {
     panic_after: Option<usize>,
 }
 
+#[cfg(test)]
 impl FixtureStreamConfig {
     pub(crate) fn try_from_raw(
         batches: i32,
@@ -671,17 +679,20 @@ impl FixtureStreamConfig {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn fixture_stream(config: FixtureStreamConfig) -> Result<FFI_ArrowArrayStream, String> {
     let reader = FixtureReader::new(config);
     Ok(record_batch_stream(Box::new(reader)))
 }
 
+#[cfg(test)]
 struct FixtureReader {
     schema: SchemaRef,
     config: FixtureStreamConfig,
     next_batch: usize,
 }
 
+#[cfg(test)]
 impl FixtureReader {
     fn new(config: FixtureStreamConfig) -> Self {
         Self {
@@ -692,6 +703,7 @@ impl FixtureReader {
     }
 }
 
+#[cfg(test)]
 impl Iterator for FixtureReader {
     type Item = Result<RecordBatch, ArrowError>;
 
@@ -721,12 +733,14 @@ impl Iterator for FixtureReader {
     }
 }
 
+#[cfg(test)]
 impl RecordBatchReader for FixtureReader {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 }
 
+#[cfg(test)]
 fn fixture_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("batch_index", DataType::Int32, false),
@@ -746,6 +760,7 @@ fn fixture_schema() -> SchemaRef {
     ]))
 }
 
+#[cfg(test)]
 fn make_fixture_batch(
     schema: SchemaRef,
     batch_index: usize,

--- a/tests/testthat/fixtures/delta/logical-types/README.md
+++ b/tests/testthat/fixtures/delta/logical-types/README.md
@@ -18,10 +18,7 @@ and refreshes `SHA256SUMS`. Re-running it with Arrow R 22.0.0 must leave both
 generated hashes unchanged. The generator itself is retained so the physical
 Arrow schema, logical Delta schema, and test values remain reviewable.
 
-Delta Kernel 0.22.0 deliberately rejects Delta interval logical types during
-schema parsing. No interval column is included in the Parquet fixture. The
-companion test mutates a copy of the Sharing metadata to
-`interval day to second` and asserts the public typed, redacted native failure
-and lifecycle cleanup instead of claiming unsupported materialization.
+Interval logical types are not included; this fixture is limited to logical
+types that the pinned Delta Kernel can materialize successfully.
 
 The fixture is package test data under the repository's Apache-2.0 license.

--- a/tests/testthat/test-api-shape.R
+++ b/tests/testthat/test-api-shape.R
@@ -110,14 +110,23 @@ test_that("print methods are stable", {
 test_that("client printing redacts endpoint user information", {
   client <- sharing_client(list(
     shareCredentialsVersion = 1,
-    endpoint = "https://user:secret@sharing.example.test/api",
+    endpoint = paste0(
+      "https://user:secret@sharing.example.test/api",
+      "?access_token=query-secret#private-fragment"
+    ),
     bearerToken = "tok"
   ))
 
   output <- capture.output(print(client))
+  expect_equal(client$endpoint(), paste0(
+    "https://user:secret@sharing.example.test/api",
+    "?access_token=query-secret#private-fragment"
+  ))
   expect_match(output, "sharing.example.test", fixed = TRUE)
   expect_false(grepl("user", output, fixed = TRUE))
   expect_false(grepl("secret", output, fixed = TRUE))
+  expect_false(grepl("access_token", output, fixed = TRUE))
+  expect_false(grepl("fragment", output, fixed = TRUE))
 })
 
 test_that("base readers require a concrete stream implementation", {

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -8,8 +8,8 @@ test_that("bearer auth applies an Authorization header", {
   ctx <- sharing_auth_context(p)
   expect_equal(ctx$kind, "bearer_token")
   req <- ctx$authenticate(httr2::request("https://x.test/api"))
-  dr <- httr2::req_dry_run(req, quiet = TRUE, redact_headers = FALSE)
-  expect_equal(dr$headers$authorization, "Bearer tok")
+  headers <- httr2::req_get_headers(req, redacted = "reveal")
+  expect_equal(headers$Authorization, "Bearer tok")
 })
 
 test_that("bearer expiration metadata does not block requests eagerly", {
@@ -21,9 +21,9 @@ test_that("bearer expiration metadata does not block requests eagerly", {
   ))
   ctx <- sharing_auth_context(p)
   req <- ctx$authenticate(httr2::request("https://x.test/api"))
-  dr <- httr2::req_dry_run(req, quiet = TRUE, redact_headers = FALSE)
+  headers <- httr2::req_get_headers(req, redacted = "reveal")
 
-  expect_equal(dr$headers$authorization, "Bearer t")
+  expect_equal(headers$Authorization, "Bearer t")
 })
 
 test_that("basic auth applies a base64 Authorization header", {
@@ -36,9 +36,9 @@ test_that("basic auth applies a base64 Authorization header", {
   ))
   ctx <- sharing_auth_context(p)
   req <- ctx$authenticate(httr2::request("https://x.test/api"))
-  dr <- httr2::req_dry_run(req, quiet = TRUE, redact_headers = FALSE)
+  headers <- httr2::req_get_headers(req, redacted = "reveal")
   expect_equal(
-    dr$headers$authorization,
+    headers$Authorization,
     paste0("Basic ", openssl::base64_encode("u:pw"))
   )
 })

--- a/tests/testthat/test-cdf-read-execution.R
+++ b/tests/testthat/test-cdf-read-execution.R
@@ -12,10 +12,11 @@ test_that("CDF requests include versioned metadata and CDF capabilities", {
   expect_equal(query$includeHistoricalMetadata, "true")
   expect_equal(query$pageToken, "next")
 
-  capabilities <- query_capabilities("delta", for_cdf = TRUE)
+  capabilities <- capability_header("delta", for_cdf = TRUE)
   expect_match(capabilities, "responseformat=delta", fixed = TRUE)
   expect_match(capabilities, "deletionvectors,columnmapping", fixed = TRUE)
   expect_false(grepl("timestampntz", capabilities, fixed = TRUE))
+  expect_false(grepl("includeendstreamaction", capabilities, fixed = TRUE))
 })
 
 test_that("CDF requests support open version and timestamp ranges", {
@@ -79,6 +80,10 @@ test_that("CDF actions retain versioned metadata and response bounds", {
   expect_equal(parsed$end_version, 4)
   expect_setequal(names(parsed$by_version), c("1", "3", "4"))
   expect_equal(parsed$by_version[["1"]]$actions[[1]]$metaData$id, "table")
+  expect_equal(
+    parsed$by_version[["1"]]$actions[[2]]$add$path,
+    "one.parquet"
+  )
   expect_equal(
     parsed$by_version[["4"]]$actions[[1]]$metaData$name,
     "renamed"
@@ -236,5 +241,27 @@ test_that("CDF action buckets require protocol and represented versions", {
     ),
     class = "delta_sharing_protocol_error"
   )
-  expect_null(find_next_page_token(list(list(protocol = list()))))
+  expect_null(find_next_page_token(list(list(protocol = list())), "changes"))
+})
+
+test_that("query pagination follows nested end stream actions", {
+  expect_equal(
+    find_next_page_token(
+      list(list(endStreamAction = list(nextPageToken = "next"))),
+      "changes"
+    ),
+    "next"
+  )
+  expect_null(find_next_page_token(list(list(protocol = list())), "changes"))
+  expect_error(
+    find_next_page_token(
+      list(list(endStreamAction = list(
+        errorMessage = "query failed",
+        httpStatusErrorCode = 500L
+      ))),
+      "changes"
+    ),
+    "query failed",
+    class = "delta_sharing_protocol_error"
+  )
 })

--- a/tests/testthat/test-e2e-kernel-read.R
+++ b/tests/testthat/test-e2e-kernel-read.R
@@ -300,7 +300,10 @@ test_that("public CDF readers paginate and materialize local change files", {
   httr2::local_mocked_responses(function(req) {
     state$page <- state$page + 1L
     page_actions <- if (state$page == 1L) {
-      c(actions[seq_len(3L)], list(list(nextPageToken = "second")))
+      c(
+        actions[seq_len(3L)],
+        list(list(endStreamAction = list(nextPageToken = "second")))
+      )
     } else {
       actions[-seq_len(3L)]
     }

--- a/tests/testthat/test-e2e-kernel-read.R
+++ b/tests/testthat/test-e2e-kernel-read.R
@@ -30,17 +30,21 @@ test_that("data-frame materialization exhausts its native stream", {
   expect_match(capture.output(print(stream)), "invalid pointer")
 })
 
-test_that("data-frame materialization preserves typed stream failures", {
+test_that("data-frame materialization preserves native stream failures", {
   stream <- native_test_stream(
     batches = 3L,
     rows_per_batch = 2L,
     error_after = 1L
   )
 
-  expect_error(
+  condition <- expect_error(
     sharing_stream_to_data_frame(stream),
-    class = "delta_sharing_kernel_error"
+    "synthetic reader error",
+    fixed = TRUE
   )
+  expect_s3_class(condition, "simpleError")
+  expect_false(inherits(condition, "delta_sharing_kernel_error"))
+  expect_match(capture.output(print(stream)), "invalid pointer")
 })
 
 test_that("the native stream boundary translates user interrupts", {
@@ -98,7 +102,7 @@ test_that("Arrow materialization exhausts its native stream", {
   expect_match(capture.output(print(stream)), "invalid pointer")
 })
 
-test_that("Arrow materialization preserves typed stream failures", {
+test_that("Arrow materialization preserves native stream failures", {
   skip_if_not_installed("arrow")
   stream <- native_test_stream(
     batches = 3L,
@@ -106,10 +110,14 @@ test_that("Arrow materialization preserves typed stream failures", {
     error_after = 1L
   )
 
-  expect_error(
+  condition <- expect_error(
     sharing_stream_to_arrow(stream),
-    class = "delta_sharing_kernel_error"
+    "synthetic reader error",
+    fixed = TRUE
   )
+  expect_s3_class(condition, "simpleError")
+  expect_false(inherits(condition, "delta_sharing_kernel_error"))
+  expect_match(capture.output(print(stream)), "invalid pointer")
 })
 
 test_that("projection selects and orders columns", {
@@ -215,7 +223,7 @@ test_that("native CDF reads the local change fixture", {
   expect_setequal(unique(changes$`_change_type`), c("delete", "insert"))
 })
 
-test_that("native condition translation releases streams and redacts failures", {
+test_that("native condition handling releases streams and preserves errors", {
   typed_stream <- native_test_stream()
   expect_error(
     with_native_stream_conditions(
@@ -237,14 +245,18 @@ test_that("native condition translation releases streams and redacts failures", 
   )
 
   failed_stream <- native_test_stream()
-  expect_error(
+  condition <- expect_error(
     with_native_stream_conditions(
-      stop("internal implementation detail"),
+      stop("consumer failure"),
       operation = "read_arrow_stream",
       stream = failed_stream
     ),
-    class = "delta_sharing_kernel_error"
+    "consumer failure",
+    fixed = TRUE
   )
+  expect_s3_class(condition, "simpleError")
+  expect_false(inherits(condition, "delta_sharing_kernel_error"))
+  expect_match(capture.output(print(failed_stream)), "invalid pointer")
 
   original <- simpleError("construction failed")
   expect_error(

--- a/tests/testthat/test-e2e-kernel-read.R
+++ b/tests/testthat/test-e2e-kernel-read.R
@@ -3,6 +3,35 @@
 # exercise the native reader, Arrow C stream, and nanoarrow conversion without a
 # network mock. This is the layer unit tests with httr2 mocks cannot cover.
 
+corrupt_snapshot_fixture <- function() {
+  table <- fs::path(
+    withr::local_tempdir(
+      pattern = "delta-sharing-corrupt-",
+      .local_envir = parent.frame()
+    ),
+    "table"
+  )
+  fs::dir_copy(fixture_table("local-table"), table)
+  writeBin(
+    charToRaw("not parquet"),
+    fs::path(table, "part-00001.parquet")
+  )
+  table
+}
+
+test_that("the installed native API contains only production entry points", {
+  routines <- getDLLRegisteredRoutines("delta.sharing")$.Call
+
+  expect_setequal(
+    names(routines),
+    c(
+      "delta_sharing_stream_from_snapshot",
+      "delta_sharing_stream_from_cdf",
+      "delta_sharing_reap_pending_cleanups"
+    )
+  )
+})
+
 test_that("kernel reads a local table to a data frame", {
   stream <- native_snapshot_stream(fixture_table("local-table"))
   df <- sharing_stream_to_data_frame(stream)
@@ -20,26 +49,15 @@ test_that("kernel reads a local table to a data frame", {
   expect_match(capture.output(print(stream)), "invalid pointer")
 })
 
-test_that("data-frame materialization exhausts its native stream", {
-  stream <- native_test_stream(batches = 3L, rows_per_batch = 2L)
-
-  df <- sharing_stream_to_data_frame(stream)
-
-  expect_s3_class(df, "data.frame")
-  expect_equal(nrow(df), 6L)
-  expect_match(capture.output(print(stream)), "invalid pointer")
-})
-
 test_that("data-frame materialization preserves native stream failures", {
-  stream <- native_test_stream(
-    batches = 3L,
-    rows_per_batch = 2L,
-    error_after = 1L
+  stream <- native_snapshot_stream(
+    corrupt_snapshot_fixture(),
+    batch_size = 2L
   )
 
   condition <- expect_error(
     sharing_stream_to_data_frame(stream),
-    "synthetic reader error",
+    "Delta Kernel data scan failed",
     fixed = TRUE
   )
   expect_s3_class(condition, "simpleError")
@@ -48,7 +66,7 @@ test_that("data-frame materialization preserves native stream failures", {
 })
 
 test_that("the native stream boundary translates user interrupts", {
-  stream <- native_test_stream()
+  stream <- native_snapshot_stream(fixture_table("local-table"))
   interrupt <- structure(
     list(message = "simulated user interrupt"),
     class = c("interrupt", "condition")
@@ -104,15 +122,14 @@ test_that("Arrow materialization exhausts its native stream", {
 
 test_that("Arrow materialization preserves native stream failures", {
   skip_if_not_installed("arrow")
-  stream <- native_test_stream(
-    batches = 3L,
-    rows_per_batch = 2L,
-    error_after = 1L
+  stream <- native_snapshot_stream(
+    corrupt_snapshot_fixture(),
+    batch_size = 2L
   )
 
   condition <- expect_error(
     sharing_stream_to_arrow(stream),
-    "synthetic reader error",
+    "Delta Kernel data scan failed",
     fixed = TRUE
   )
   expect_s3_class(condition, "simpleError")
@@ -224,7 +241,7 @@ test_that("native CDF reads the local change fixture", {
 })
 
 test_that("native condition handling releases streams and preserves errors", {
-  typed_stream <- native_test_stream()
+  typed_stream <- native_snapshot_stream(fixture_table("local-table"))
   expect_error(
     with_native_stream_conditions(
       abort("bad protocol", type = "protocol"),
@@ -234,7 +251,7 @@ test_that("native condition handling releases streams and preserves errors", {
     class = "delta_sharing_protocol_error"
   )
 
-  interrupted_stream <- native_test_stream()
+  interrupted_stream <- native_snapshot_stream(fixture_table("local-table"))
   expect_error(
     with_native_stream_conditions(
       stop(native_stream_interrupt_message),
@@ -244,7 +261,7 @@ test_that("native condition handling releases streams and preserves errors", {
     class = "delta_sharing_cancelled"
   )
 
-  failed_stream <- native_test_stream()
+  failed_stream <- native_snapshot_stream(fixture_table("local-table"))
   condition <- expect_error(
     with_native_stream_conditions(
       stop("consumer failure"),
@@ -270,7 +287,7 @@ test_that("native condition handling releases streams and preserves errors", {
 })
 
 test_that("interruptible streams preserve non-pull methods", {
-  stream <- native_test_stream()
+  stream <- native_snapshot_stream(fixture_table("local-table"))
   withr::defer(release_materializer_stream(stream))
 
   expect_type(stream$get_schema, "closure")

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -34,17 +34,20 @@ test_that("wire projections do not silently coerce or truncate values", {
 })
 
 test_that("metadata fields retain their wire types", {
-  body <- ndjson_body(list(list(
-    metadata = list(
-      id = 42,
-      name = "events",
-      schemaString = "{\"type\":\"struct\",\"fields\":[]}",
-      partitionColumns = list(),
-      numFiles = "5",
-      size = "not-a-number",
-      createdTime = "yesterday"
+  body <- ndjson_body(list(
+    list(protocol = list(minReaderVersion = 1L)),
+    list(
+      metadata = list(
+        id = 42,
+        name = "events",
+        schemaString = "{\"type\":\"struct\",\"fields\":[]}",
+        partitionColumns = list(),
+        numFiles = "5",
+        size = "not-a-number",
+        createdTime = "yesterday"
+      )
     )
-  )))
+  ))
   response <- httr2::response(200, body = charToRaw(body))
 
   metadata <- parse_table_actions(response, "metadata")$metadata
@@ -53,6 +56,26 @@ test_that("metadata fields retain their wire types", {
   expect_identical(metadata$num_files, "5")
   expect_identical(metadata$size, "not-a-number")
   expect_identical(metadata$created_time, "yesterday")
+})
+
+test_that("metadata responses require protocol and metadata actions", {
+  protocol_only <- httr2::response(
+    200,
+    body = charToRaw(ndjson_body(list(list(protocol = list()))))
+  )
+  metadata_only <- httr2::response(
+    200,
+    body = charToRaw(ndjson_body(list(list(metadata = list(id = "table")))))
+  )
+
+  expect_error(
+    parse_table_actions(protocol_only, "metadata"),
+    class = "delta_sharing_protocol_error"
+  )
+  expect_error(
+    parse_table_actions(metadata_only, "metadata"),
+    class = "delta_sharing_protocol_error"
+  )
 })
 
 test_that("table protocol projects delta reader features", {

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -234,6 +234,10 @@ test_that("metadata protocol validation rejects invalid wire responses", {
     class = "delta_sharing_protocol_error"
   )
   expect_length(parse_ndjson_lines("\n \n", "metadata"), 0L)
+  expect_equal(
+    parse_ndjson_lines('{"a":1}\n\n {"b":[2,3]}\n', "metadata"),
+    list(list(a = 1L), list(b = list(2L, 3L)))
+  )
 })
 
 test_that("parquet metadata envelopes are projected safely", {

--- a/tests/testthat/test-query-body.R
+++ b/tests/testthat/test-query-body.R
@@ -53,6 +53,14 @@ test_that("snapshot timestamps are formatted for the wire", {
   )
 })
 
+test_that("snapshot version and timestamp are both sent when supplied", {
+  timestamp <- as.POSIXct("2026-01-01", tz = "UTC")
+  body <- query_body(list(version = 3, timestamp = timestamp), NULL)
+
+  expect_identical(body$version, 3)
+  expect_identical(body$timestamp, "2026-01-01T00:00:00Z")
+})
+
 test_that("parquet action helpers validate required wire fields", {
   expect_equal(as_json_map(NULL), rlang::set_names(list(), character()))
   expect_equal(as_json_map(c(a = 1)), list(a = 1))

--- a/tests/testthat/test-snapshot-read-execution.R
+++ b/tests/testthat/test-snapshot-read-execution.R
@@ -45,7 +45,7 @@ test_that("snapshot pages append to one private commit", {
       expect_null(req$body$data$pageToken)
       actions <- c(
         snapshot_delta_actions(),
-        list(list(nextPageToken = "page-two"))
+        list(list(endStreamAction = list(nextPageToken = "page-two")))
       )
     } else {
       expect_equal(req$body$data$pageToken, "page-two")
@@ -164,7 +164,7 @@ test_that("a malformed later page removes incomplete snapshot staging", {
     if (state$page == 1L) {
       actions <- c(
         snapshot_delta_actions(),
-        list(list(nextPageToken = "broken-page"))
+        list(list(endStreamAction = list(nextPageToken = "broken-page")))
       )
       return(httr2::response(
         200,
@@ -204,8 +204,10 @@ test_that("snapshot responses require protocol and metadata", {
   httr2::local_mocked_responses(function(req) {
     httr2::response(
       200,
-      body = charToRaw(ndjson_body(list(list(nextPageToken = ""))))
-    )
+      body = charToRaw(ndjson_body(list(list(
+        endStreamAction = list(nextPageToken = "")
+      )))
+    ))
   })
   profile <- test_profile()
 


### PR DESCRIPTION
## Summary

- fix snapshot and CDF pagination around nested `endStreamAction` responses and reduce repeated CDF parsing work
- simplify metadata, endpoint, validation, and snapshot-staging code without changing the public reader model
- preserve Arrow, nanoarrow, and consumer error classes while still translating user interrupts
- remove the shipped synthetic native test stream and keep fixture machinery restricted to Rust unit tests
- exercise mid-stream failures through a real corrupted local Delta fixture and restrict the installed native API to production entry points

## Impact

This keeps the existing client/table/read surface while making query handling more correct and the native boundary smaller. The installed library now exposes only snapshot, CDF, and cleanup functions. No credentials, live profiles, benchmark outputs, or private test assets are included.

## Validation

- full R test suite
- 14 Rust unit tests
- `cargo clippy --locked --all-targets -- -D warnings`
- built-source `R CMD check`: **Status OK**
- installed-library symbol audit
- pre-commit, commit-message, and pre-push secret scans