### PR TITLE
Speed up pkgdown CI builds

### DIFF
--- a/.github/workflows/pkgdown-check.yaml
+++ b/.github/workflows/pkgdown-check.yaml
@@ -11,8 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target
-  CARGO_TERM_COLOR: always
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   R_KEEP_PKG_SOURCE: yes
 
@@ -28,17 +26,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
-        with:
-          toolchain: stable
-
-      - name: Restore Rust build cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: src/rust -> ../../.cargo-target
-          shared-key: r-package-release
-
       - name: Install R
         uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
@@ -50,10 +37,15 @@ jobs:
       - name: Install site dependencies
         uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown
           needs: website
           cache-version: 1
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: >-
+          pkgdown::build_site_github_pages(
+            new_process = FALSE,
+            install = FALSE,
+            examples = FALSE
+          )
         shell: Rscript {0}

--- a/.github/workflows/pkgdown-deploy.yaml
+++ b/.github/workflows/pkgdown-deploy.yaml
@@ -14,8 +14,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  CARGO_TARGET_DIR: ${{ github.workspace }}/.cargo-target
-  CARGO_TERM_COLOR: always
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   R_KEEP_PKG_SOURCE: yes
 
@@ -31,17 +29,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
-        with:
-          toolchain: stable
-
-      - name: Restore Rust build cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: src/rust -> ../../.cargo-target
-          shared-key: r-package-release
-
       - name: Install R
         uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
@@ -53,12 +40,17 @@ jobs:
       - name: Install site dependencies
         uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown
           needs: website
           cache-version: 1
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: >-
+          pkgdown::build_site_github_pages(
+            new_process = FALSE,
+            install = FALSE,
+            examples = FALSE
+          )
         shell: Rscript {0}
 
       - name: Upload site artifact


### PR DESCRIPTION
## Summary

- stop compiling and installing the Rust-backed local package in pkgdown check/deploy jobs
- build documentation without examples; package examples remain covered by the full R CMD check matrix
- keep the existing package, coverage, CRAN source-build, vignette, and cross-platform gates unchanged

This branch is based on integration commit `263bdbc` from `codex/query-cdf-performance` (draft PR #21). Until #21 lands, this draft is intentionally stacked in its commit history while using the repository default branch (`main`) as the eventual PR base.

## Timing evidence

Baseline run: https://github.com/zacdav-db/delta-sharing-r/actions/runs/31553462969

- pkgdown check job: 229 seconds
- `Install site dependencies`: 170 seconds
- local `delta.sharing` build inside that step: about 120 seconds
- actual `Build site`: 11 seconds

The package-check critical path is native compilation rather than R dependency download: the source package build spent 345 seconds in `R CMD build`, and the platform `R CMD check` steps spent 171-498 seconds. Those CRAN/package coverage paths are deliberately unchanged.

## Package mirror findings

The workflows already request public Posit Package Manager. Hosted logs show:

- Ubuntu 24.04 uses the Noble Posit repository and resolves CRAN dependencies as Linux binaries (42-47 seconds on warm package caches).
- Ubuntu 22.04 is supported by Posit and its warm dependency setup was 46 seconds.
- Windows uses Posit Windows binaries and took 40 seconds.
- macOS arm64/x86_64 use CRAN native binaries because `r-lib/actions/setup-r` only enables public RSPM on x86_64 Linux/Windows for `use-public-rspm: true`; their dependency setup took 26/43 seconds. Forcing `always` has no measured benefit here, so this PR does not change repositories.

## Validation

- `actionlint` 1.7.12
- parsed all workflow YAML files
- built the complete pkgdown site with Pandoc 3.8.3, `install = FALSE`, and `examples = FALSE`; verified home, reference, article, news, sitemap, and search outputs
- `git diff --check`
- repository secret-scan commit hook
