### PR TITLE
Review read API and conformance coverage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Config/testthat/edition: 3
 Config/testthat/parallel: false
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-SystemRequirements: Cargo (Rust's package manager), rustc (>= 1.88), CMake
+SystemRequirements: Cargo (Rust's package manager), rustc (>= 1.88)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,9 @@
 
 S3method("$",delta_sharing_interruptible_stream)
 S3method(print,delta_sharing_listing)
+S3method(print,delta_sharing_metadata)
+S3method(print,delta_sharing_protocol)
+S3method(print,delta_sharing_schema)
 export(SharingChanges)
 export(SharingClient)
 export(SharingSnapshot)

--- a/R/auth.R
+++ b/R/auth.R
@@ -115,16 +115,12 @@ sharing_auth_context <- function(profile) {
     )
   )
 
-  structure(
-    list(
-      kind = kind,
-      authenticate = authenticate,
-      # Response-format negotiation is stable for a table within one client
-      # session. Keep this cache beside the shared auth context so every table
-      # handle and reader created by the client sees the same result without
-      # introducing package-global state.
-      response_format_cache = new.env(parent = emptyenv())
-    ),
-    class = "delta_sharing_auth"
+  list(
+    authenticate = authenticate,
+    # Response-format negotiation is stable for a table within one client
+    # session. Keep this cache beside the shared auth context so every table
+    # handle and reader created by the client sees the same result without
+    # introducing package-global state.
+    response_format_cache = new.env(parent = emptyenv())
   )
 }

--- a/R/conditions.R
+++ b/R/conditions.R
@@ -7,7 +7,6 @@ condition_classes <- list(
   validation = "delta_sharing_validation_error",
   auth = "delta_sharing_auth_error",
   protocol = "delta_sharing_protocol_error",
-  kernel = "delta_sharing_kernel_error",
   unsupported = "delta_sharing_unsupported_error",
   cancelled = "delta_sharing_cancelled"
 )
@@ -15,7 +14,7 @@ condition_classes <- list(
 #' Delta Sharing conditions
 #'
 #' Package-specific errors inherit from `delta_sharing_error`. More specific
-#' subclasses identify validation, authentication, protocol, kernel,
+#' subclasses identify validation, authentication, protocol,
 #' unsupported-feature, and cancellation failures. HTTP requests and Arrow
 #' consumers retain their native condition classes and messages. User
 #' interrupts are reported as cancellation failures.

--- a/R/discovery.R
+++ b/R/discovery.R
@@ -11,9 +11,14 @@ print.delta_sharing_listing <- function(x, ...) {
     tables = c("share", "schema", "name")
   )
   cat(sprintf("<Delta Sharing %s> %d\n", kind, length(x)))
-  purrr::walk(x, function(record) {
+  shown <- utils::head(x, 10L)
+  purrr::walk(shown, function(record) {
     cat("  ", paste(unlist(record[fields]), collapse = "."), "\n", sep = "")
   })
+  remaining <- length(x) - length(shown)
+  if (remaining > 0L) {
+    cat(sprintf("  ... and %d more\n", remaining))
+  }
   invisible(x)
 }
 
@@ -35,7 +40,10 @@ sharing_list_schemas <- function(profile, auth, share) {
     "list_schemas"
   )
   records <- purrr::map(items, \(item) {
-    c(list(share = share), item)
+    c(
+      list(share = item$share %||% share),
+      item[setdiff(names(item), "share")]
+    )
   })
   structure(
     records,

--- a/R/file-staging.R
+++ b/R/file-staging.R
@@ -53,13 +53,9 @@ staged_asset <- function(kind, id, url, size = NULL) {
   )
 }
 
-file_wrapper_action <- function(file, response_format, operation) {
-  synthetic_file_action(file, response_format, operation)
-}
-
 # Expand one shared file into the data and deletion-vector assets it needs.
 file_wrapper_assets <- function(file, response_format, operation) {
-  action <- file_wrapper_action(file, response_format, operation)
+  action <- synthetic_file_action(file, response_format, operation)
   field <- delta_file_field(action)
   if (is.null(field)) {
     return(list())
@@ -234,7 +230,7 @@ ensure_staged_assets <- function(assets, cache_path, concurrency) {
 
 # Point a Delta action at its cached data and deletion-vector files.
 rewrite_staged_file <- function(file, response_format, operation, paths) {
-  action <- file_wrapper_action(file, response_format, operation)
+  action <- synthetic_file_action(file, response_format, operation)
   field <- delta_file_field(action)
   if (is.null(field)) {
     return(action)

--- a/R/http.R
+++ b/R/http.R
@@ -72,14 +72,13 @@ sharing_paginate <- function(
   profile,
   auth,
   path,
-  operation,
-  max_results = 500L
+  operation
 ) {
   first <- sharing_request(
     profile,
     auth,
     path,
-    query = list(maxResults = max_results)
+    query = list(maxResults = 500L)
   )
   next_token <- function(resp) {
     token <- discovery_body(resp, operation)$nextPageToken

--- a/R/http.R
+++ b/R/http.R
@@ -72,13 +72,14 @@ sharing_paginate <- function(
   profile,
   auth,
   path,
-  operation
+  operation,
+  max_results = 500L
 ) {
   first <- sharing_request(
     profile,
     auth,
     path,
-    query = list(maxResults = 500L)
+    query = list(maxResults = max_results)
   )
   next_token <- function(resp) {
     token <- discovery_body(resp, operation)$nextPageToken

--- a/R/kernel-log.R
+++ b/R/kernel-log.R
@@ -51,32 +51,6 @@ synthetic_log_header <- function(
   }
 }
 
-# Turn a parsed Query Table response into the ordered JSON lines of the
-# synthetic commit: protocol, metadata, then one line per file action.
-synthetic_log_lines <- function(
-  response_format,
-  protocol,
-  metadata,
-  files,
-  operation = "read"
-) {
-  file_lines <- purrr::map_chr(
-    files,
-    function(file) {
-      log_json_line(synthetic_file_action(file, response_format, operation))
-    }
-  )
-  c(
-    synthetic_log_header(
-      response_format,
-      protocol,
-      metadata,
-      operation
-    ),
-    file_lines
-  )
-}
-
 # Delta format: the file action already carries a fully-formed single action.
 # Parquet format: synthesize a flat `add` from the sharing file fields.
 synthetic_file_action <- function(file, response_format, operation) {
@@ -105,14 +79,6 @@ prepare_log <- function(write) {
   )
 }
 
-# Snapshot: a single version-0 commit holding protocol, metadata, and adds.
-prepare_synthetic_log <- function(lines) {
-  prepare_log(function(log_dir) {
-    writeLines(lines, fs::path(log_dir, log_commit_name), useBytes = TRUE)
-    invisible(NULL)
-  })
-}
-
 # Change data feed: the kernel's TableChanges reads a real multi-version log,
 # so this writes one commit per version across the observed `[start, end]` range
 # (including interior versions with no changes). The protocol goes in the first
@@ -122,17 +88,6 @@ prepare_synthetic_log <- function(lines) {
 # commits.
 # `by_version` is keyed by as.character(version) ->
 # list(timestamp_ms=, actions=list(...)); `protocol` is pre-unwrapped.
-prepare_cdf_log <- function(protocol, by_version, start_version, end_version) {
-  log <- prepare_log(function(log_dir) {
-    write_cdf_log(log_dir, protocol, by_version, start_version, end_version)
-    invisible(NULL)
-  })
-
-  log$start_version <- start_version
-  log$end_version <- end_version
-  log
-}
-
 write_cdf_log <- function(
   log_dir,
   protocol,

--- a/R/read-execution.R
+++ b/R/read-execution.R
@@ -410,17 +410,6 @@ sharing_changes_stream <- function(
   batch_size = 65536L,
   concurrency = 4L
 ) {
-  # Change data feed is read through the kernel, which requires delta format;
-  # the parquet CDF path is not supported. An explicit parquet request is a
-  # user error, so reject it rather than silently upgrading.
-  if (identical(spec$response_format, "parquet")) {
-    abort(
-      "Parquet-format change data feed is not supported.",
-      type = "unsupported",
-      operation = "changes",
-      feature = "parquet_cdf"
-    )
-  }
   parsed <- sharing_query_changes(
     profile,
     auth,
@@ -462,8 +451,8 @@ sharing_stream_to_arrow_reader <- function(
 }
 
 sharing_stream_to_arrow <- function(stream) {
-  force(stream)
   require_arrow("to_arrow")
+  force(stream)
   on.exit(release_materializer_stream(stream), add = TRUE)
   reader <- sharing_stream_to_arrow_reader(stream, operation = "to_arrow")
   with_native_stream_conditions(
@@ -481,8 +470,4 @@ sharing_stream_to_tibble <- function(stream) {
     operation = "read_arrow_stream",
     stream = stream
   )
-}
-
-sharing_stream_to_data_frame <- function(stream) {
-  as.data.frame(sharing_stream_to_tibble(stream))
 }

--- a/R/readers.R
+++ b/R/readers.R
@@ -1,7 +1,7 @@
 # Reader objects returned by SharingTable$snapshot() / $changes(). Query options
 # are fixed at construction; the eager materializers (to_arrow, to_tibble,
-# to_data_frame) are adapters over the one lazy Arrow stream, so there is a
-# single read path.
+# to_data_frame) use the same Arrow C stream path. Each materializer call opens
+# a new stream.
 # SharingReader holds that shared behaviour; the subclasses differ only in how
 # they validate options and open the native stream.
 
@@ -26,8 +26,7 @@ SharingReader <- R6::R6Class(
 
     #' @description Expose a lazy Arrow record batch reader (requires
     #'   `{arrow}`). The reader owns the underlying stream; consume it or call
-    #'   its `Close()` method. Downstream consumers must serialize pulls from
-    #'   this single-consumer stream.
+    #'   its `Close()` method.
     #' @param batch_size Rows per batch.
     #' @return An `arrow::RecordBatchReader`.
     to_arrow_reader = function(batch_size = 65536L) {
@@ -73,6 +72,40 @@ SharingReader <- R6::R6Class(
         id$schema,
         id$table
       ))
+      spec <- private$spec
+      read <- if (inherits(self, "SharingSnapshot")) {
+        read <- "latest snapshot"
+        if (!is.null(spec$version)) {
+          read <- paste("version", spec$version)
+        }
+        if (!is.null(spec$timestamp)) {
+          read <- paste("at", format_timestamp(spec$timestamp))
+        }
+        read
+      } else {
+        start <- if (is.null(spec$starting_version)) {
+          format_timestamp(spec$starting_timestamp %||% "?")
+        } else {
+          spec$starting_version
+        }
+        end <- if (is.null(spec$ending_version)) {
+          format_timestamp(spec$ending_timestamp %||% "latest")
+        } else {
+          spec$ending_version
+        }
+        paste("changes", start, "to", end)
+      }
+      details <- c(
+        read,
+        if (!is.null(spec$columns)) {
+          paste(
+            length(spec$columns),
+            if (length(spec$columns) == 1L) "column" else "columns"
+          )
+        },
+        if (!is.null(spec$limit)) paste0("limit ", spec$limit)
+      )
+      cat("  ", paste(details, collapse = " | "), "\n", sep = "")
       invisible(self)
     }
   ),
@@ -191,7 +224,7 @@ SharingChanges <- R6::R6Class(
   public = list(
     #' @description Create a changes reader. Prefer `SharingTable$changes()`.
     #' @param profile,auth,identifier Internal client state.
-    #' @param starting_version,ending_version,starting_timestamp,ending_timestamp,columns,response_format
+    #' @param starting_version,ending_version,starting_timestamp,ending_timestamp,columns
     #'   Query options; see [SharingTable]'s `changes()` method.
     #' @param cache_path,concurrency Internal table execution settings.
     initialize = function(
@@ -203,7 +236,6 @@ SharingChanges <- R6::R6Class(
       starting_timestamp = NULL,
       ending_timestamp = NULL,
       columns = NULL,
-      response_format = "auto",
       cache_path,
       concurrency
     ) {
@@ -224,11 +256,7 @@ SharingChanges <- R6::R6Class(
         ending_version = ending_version,
         starting_timestamp = starting_timestamp,
         ending_timestamp = ending_timestamp,
-        columns = columns,
-        response_format = rlang::arg_match0(
-          response_format,
-          c("auto", "delta", "parquet")
-        )
+        columns = columns
       )
       invisible(self)
     }

--- a/R/table-metadata.R
+++ b/R/table-metadata.R
@@ -106,9 +106,7 @@ metadata_request <- function(
 }
 
 parse_version_header <- function(resp, operation) {
-  value <- suppressWarnings(
-    as.numeric(httr2::resp_header(resp, "delta-table-version"))
-  )
+  value <- as.numeric(httr2::resp_header(resp, "delta-table-version"))
   if (!rlang::is_scalar_integerish(value, finite = TRUE) || value < 0) {
     abort(
       "The server did not return a valid table version.",
@@ -117,6 +115,53 @@ parse_version_header <- function(resp, operation) {
     )
   }
   value
+}
+
+#' @export
+print.delta_sharing_protocol <- function(x, ...) {
+  cat(sprintf("<Delta Sharing protocol> %s\n", x$response_format))
+  cat(sprintf("  reader version: %s\n", x$min_reader_version))
+  if (length(x$reader_features) > 0L) {
+    cat(
+      "  reader features: ",
+      paste(x$reader_features, collapse = ", "),
+      "\n",
+      sep = ""
+    )
+  }
+  invisible(x)
+}
+
+#' @export
+print.delta_sharing_metadata <- function(x, ...) {
+  cat(sprintf("<Delta Sharing metadata> %s\n", x$name))
+  cat(sprintf(
+    "  table version: %s | response format: %s\n",
+    x$table_version,
+    x$response_format
+  ))
+  cat(sprintf("  files: %s | size: %s bytes\n", x$num_files, x$size))
+  invisible(x)
+}
+
+#' @export
+print.delta_sharing_schema <- function(x, ...) {
+  fields <- x$fields %||% list()
+  field_names <- purrr::map_chr(fields, "name")
+  cat(sprintf(
+    "<Delta Sharing schema> %d field%s\n",
+    length(fields),
+    if (length(fields) == 1L) "" else "s"
+  ))
+  shown <- utils::head(field_names, 10L)
+  if (length(shown) > 0L) {
+    cat("  ", paste(shown, collapse = ", "), "\n", sep = "")
+  }
+  remaining <- length(field_names) - length(shown)
+  if (remaining > 0L) {
+    cat(sprintf("  ... and %d more\n", remaining))
+  }
+  invisible(x)
 }
 
 # Parse one buffered NDJSON page as a JSON array, ignoring empty lines.

--- a/R/table.R
+++ b/R/table.R
@@ -98,15 +98,13 @@ SharingTable <- R6::R6Class(
     #' @param starting_timestamp,ending_timestamp Optional timestamp strings or
     #'   `POSIXct` bounds.
     #' @param columns Optional character vector of projected columns.
-    #' @param response_format One of `"auto"`, `"delta"`, or `"parquet"`.
     #' @return A [SharingChanges].
     changes = function(
       starting_version = NULL,
       ending_version = NULL,
       starting_timestamp = NULL,
       ending_timestamp = NULL,
-      columns = NULL,
-      response_format = "auto"
+      columns = NULL
     ) {
       SharingChanges$new(
         profile = private$profile,
@@ -117,7 +115,6 @@ SharingTable <- R6::R6Class(
         starting_timestamp = starting_timestamp,
         ending_timestamp = ending_timestamp,
         columns = columns,
-        response_format = response_format,
         cache_path = private$cache_directory,
         concurrency = private$concurrency
       )
@@ -132,6 +129,7 @@ SharingTable <- R6::R6Class(
         private$id$schema,
         private$id$table
       ))
+      cat(sprintf("  concurrent downloads: %s\n", private$concurrency))
       invisible(self)
     }
   ),

--- a/README.md
+++ b/README.md
@@ -25,31 +25,20 @@ library(delta.sharing)
 
 client <- sharing_client(demo_profile())
 
-# Discover the public example data
-client$list_shares()
-client$list_schemas("delta_sharing")
+# Discover the public example tables
 client$list_tables("delta_sharing")
 
-# Create a reusable table handle
 housing <- client$table("delta_sharing.default.boston-housing")
-
-# Inspect metadata without scanning rows
-housing$version()
-housing$metadata()
-housing$schema()
-
-# Read a snapshot
-snapshot <- housing$snapshot(limit = 1000)
-housing_tbl <- snapshot$to_tibble()
-housing_df <- snapshot$to_data_frame()
-housing_arrow <- snapshot$to_arrow()
+housing_tbl <- housing$snapshot(limit = 1000)$to_tibble()
 ```
 
-`to_tibble()` is the usual eager R materializer. `to_data_frame()` returns the
-same result as a base data frame, while `to_arrow()` keeps it in Arrow memory.
-All three consume the same direct Arrow stream without an intermediate replay.
+`to_tibble()` is the usual eager R materializer. The same reader can instead
+return a base data frame with `to_data_frame()`, an Arrow table with
+`to_arrow()`, or a lazy Arrow reader with `to_arrow_reader()`. The Arrow
+materializers require the optional `arrow` package.
 
-The default `response_format = "auto"` negotiation is reused for subsequent
+Each materializer call performs its own read through the same Arrow C stream
+path. For snapshots, the default response format negotiation is reused by later
 reads of the same table through one client. Metadata and schema inspection
 remain fresh requests.
 
@@ -57,7 +46,7 @@ For your own share, pass a profile file and select its table:
 
 ```r
 client <- sharing_client("~/config.share")
-orders <- client$table("sales.default.orders", concurrency = 4)
+orders <- client$table("sales.default.orders")
 ```
 
 ## Snapshots and changes
@@ -92,62 +81,75 @@ refreshed_tbl <- orders$snapshot()$to_tibble()
 orders$cache_path
 ```
 
-Set `concurrency` when creating the table handle to tune downloads. R removes
-the cache with its session temporary directory. Advanced users can delete
-`orders$cache_path` manually; do not do that while a lazy reader is active.
-Interactive downloads report completed files and total bytes when sizes are
-available from the sharing server.
+Set `concurrency` when creating the table handle to tune downloads. The cache is
+stored in R's session temporary directory and is normally removed when R exits.
+Advanced users can delete `orders$cache_path` manually; do not do that while a
+lazy reader is active. Interactive missing-file downloads report completed
+files and total bytes when sizes are available from the sharing server.
 
 See `vignette("delta-sharing")` for a full walkthrough.
 
 ## Query with DuckDB
 
-DuckDB accepts both Arrow materializers:
+DuckDB accepts both Arrow materializers after the selected files have been
+staged in the session cache:
 
-- `to_arrow_reader()` is lazy and suited to one pass over a large result.
+- `to_arrow_reader()` streams rows lazily and is suited to one pass over a large
+  result.
 - `to_arrow()` materializes an Arrow table in memory and is useful when DuckDB
   should scan the same result more than once.
 
 Both avoid an intermediate R data frame. This requires the optional `arrow`,
-`DBI`, `duckdb`, and `withr` packages.
+`DBI`, and `duckdb` packages.
+
+For a one-pass query, register an Arrow reader:
 
 ```r
-snapshot <- orders$snapshot(
-  columns = c("status", "amount")
+snapshot <- housing$snapshot(
+  columns = c("chas", "medv")
 )
-
 reader <- snapshot$to_arrow_reader()
 
-con <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
-duckdb::duckdb_register_arrow(con, "shared_orders", reader)
+con <- DBI::dbConnect(duckdb::duckdb())
+duckdb::duckdb_register_arrow(con, "housing", reader)
 
-revenue <- withr::with_options(
-  list(arrow.use_threads = FALSE),
-  DBI::dbGetQuery(con, "
-    SELECT status, count(*) AS orders, sum(amount) AS revenue
-    FROM shared_orders
-    GROUP BY status
-    ORDER BY revenue DESC
-  ")
-)
+summary <- DBI::dbGetQuery(con, "
+  SELECT chas, count(*) AS homes, avg(medv) AS mean_value
+  FROM housing
+  GROUP BY chas
+  ORDER BY chas
+")
+summary
+#>   chas homes mean_value
+#> 1    0   471   22.29553
+#> 2    1    35   30.17500
 
-duckdb::duckdb_unregister_arrow(con, "shared_orders")
-DBI::dbDisconnect(con, shutdown = TRUE)
+duckdb::duckdb_unregister_arrow(con, "housing")
 reader$Close()
+DBI::dbDisconnect(con)
 ```
 
-The scoped Arrow option keeps pulls from the one-pass reader serial. It does
-not limit DuckDB's query threads.
-
-For the eager path, replace the reader construction and registration lines
-above with:
+For a reusable in-memory result, register an Arrow table:
 
 ```r
+snapshot <- housing$snapshot(
+  columns = c("chas", "medv")
+)
 arrow_table <- snapshot$to_arrow()
-duckdb::duckdb_register_arrow(con, "shared_orders", arrow_table)
-```
 
-An eager Arrow table does not need the scoped Arrow option.
+con <- DBI::dbConnect(duckdb::duckdb())
+duckdb::duckdb_register_arrow(con, "housing", arrow_table)
+
+summary <- DBI::dbGetQuery(con, "
+  SELECT chas, count(*) AS homes, avg(medv) AS mean_value
+  FROM housing
+  GROUP BY chas
+  ORDER BY chas
+")
+
+duckdb::duckdb_unregister_arrow(con, "housing")
+DBI::dbDisconnect(con)
+```
 
 An Arrow reader is single-consumer. Use an Arrow table, or create a temporary
 DuckDB table during the first query, when the result needs to be scanned
@@ -155,9 +157,11 @@ several times.
 
 ## Performance
 
-Median end-to-end snapshot times from three `to_tibble()` reads at the default
-concurrency of four. A cached read repeats the query after its selected files
-have been downloaded into the session cache.
+Directional results from one consumer setup. Each value is the median of three
+end-to-end `to_tibble()` reads at the default concurrency of four. A cached read
+repeats the query after its selected files have been downloaded into the session
+cache. The benchmark can be rerun with
+[`bench/snapshot.R`](bench/snapshot.R).
 
 *Apple M2 Pro (12 cores), 32 GB RAM, R 4.5.1; VPN connection: 92 Mbps down,
 111 ms base round-trip latency.*

--- a/inst/dependency-licenses/dependency-inventory.json
+++ b/inst/dependency-licenses/dependency-inventory.json
@@ -167,7 +167,7 @@
     }
   ],
   "rust": {
-    "cargo_lock_sha256": "d4d289d9233de4a56b92d7e91785bb5acce5de5bcf11a4e66f5de1489fb488da",
+    "cargo_lock_sha256": "ed0447c8e52e2c3cd45bd769a0870b5a3a984723b5e5aeb489ceebd6c12ba7f7",
     "license_bundle": {
       "bytes": 43032,
       "path": "rust-license-texts.tar.xz",

--- a/man/SharingChanges.Rd
+++ b/man/SharingChanges.Rd
@@ -48,7 +48,6 @@ Create a changes reader. Prefer \code{SharingTable$changes()}.
   starting_timestamp = NULL,
   ending_timestamp = NULL,
   columns = NULL,
-  response_format = "auto",
   cache_path,
   concurrency
 )}\if{html}{\out{</div>}}
@@ -59,7 +58,7 @@ Create a changes reader. Prefer \code{SharingTable$changes()}.
 \describe{
 \item{\code{profile, auth, identifier}}{Internal client state.}
 
-\item{\code{starting_version, ending_version, starting_timestamp, ending_timestamp, columns, response_format}}{Query options; see \link{SharingTable}'s \code{changes()} method.}
+\item{\code{starting_version, ending_version, starting_timestamp, ending_timestamp, columns}}{Query options; see \link{SharingTable}'s \code{changes()} method.}
 
 \item{\code{cache_path, concurrency}}{Internal table execution settings.}
 }

--- a/man/SharingReader.Rd
+++ b/man/SharingReader.Rd
@@ -50,8 +50,7 @@ An \code{arrow::Table}.
 \subsection{Method \code{to_arrow_reader()}}{
 Expose a lazy Arrow record batch reader (requires
 \code{{arrow}}). The reader owns the underlying stream; consume it or call
-its \code{Close()} method. Downstream consumers must serialize pulls from
-this single-consumer stream.
+its \code{Close()} method.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{SharingReader$to_arrow_reader(batch_size = 65536L)}\if{html}{\out{</div>}}
 }

--- a/man/SharingTable.Rd
+++ b/man/SharingTable.Rd
@@ -174,8 +174,7 @@ Configure a change data feed read.
   ending_version = NULL,
   starting_timestamp = NULL,
   ending_timestamp = NULL,
-  columns = NULL,
-  response_format = "auto"
+  columns = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -188,8 +187,6 @@ Configure a change data feed read.
 \code{POSIXct} bounds.}
 
 \item{\code{columns}}{Optional character vector of projected columns.}
-
-\item{\code{response_format}}{One of \code{"auto"}, \code{"delta"}, or \code{"parquet"}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/delta_sharing_conditions.Rd
+++ b/man/delta_sharing_conditions.Rd
@@ -5,7 +5,7 @@
 \title{Delta Sharing conditions}
 \description{
 Package-specific errors inherit from \code{delta_sharing_error}. More specific
-subclasses identify validation, authentication, protocol, kernel,
+subclasses identify validation, authentication, protocol,
 unsupported-feature, and cancellation failures. HTTP requests and Arrow
 consumers retain their native condition classes and messages. User
 interrupts are reported as cancellation failures.

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -638,7 +638,6 @@ dependencies = [
  "arrow-schema",
  "delta_kernel",
  "delta_kernel_default_engine",
- "parquet",
  "url",
 ]
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -23,9 +23,6 @@ delta_kernel_default_engine = { version = "=0.26.0", default-features = false, f
 ] }
 url = "=2.5.8"
 
-[dev-dependencies]
-parquet = { version = "=58.3.0", default-features = false, features = ["arrow", "snap"] }
-
 [profile.release]
 lto = "thin"
 panic = "unwind"

--- a/tests/testthat/fixtures/cdfx/README.md
+++ b/tests/testthat/fixtures/cdfx/README.md
@@ -19,11 +19,10 @@ portable R source archives. Within each fixture, `l` contains commits in
 version order and `p` contains Parquet payloads in bytewise order of their
 original relative paths.
 
-Tests reconstruct the original path mapping, transform the committed Delta
-actions into Delta Sharing wire actions, then exercise the production R
-decoder, private synthetic-log builder, Delta Kernel CDF reader, and Arrow
-stream. URLs are replaced with local fixture paths only after R has validated
-and written the synthetic log.
+Tests reconstruct the original path mapping and wrap each local fixture URL in
+a mocked Delta Sharing wire action. The production R path then stages those
+payloads, rewrites their actions to the staged locations, builds the private
+synthetic log, and reads it through Delta Kernel and the Arrow stream boundary.
 
 The upstream Apache License 2.0 text is redistributed verbatim as `LICENSE`.
 Its SHA-256 is

--- a/tests/testthat/fixtures/delta/feature-conformance.md
+++ b/tests/testthat/fixtures/delta/feature-conformance.md
@@ -16,6 +16,6 @@ in the Delta Sharing capabilities header:
 The Parquet payloads were written with Arrow 22.0.0. The inline Z85 payload is
 the writer's portable 36-byte bitmap body without its persisted-file framing.
 Every test decodes a Delta Sharing response wrapper, constructs the package's
-private synthetic log, and reads through the production Delta Kernel 0.22 to
+private synthetic log, and reads through the production Delta Kernel 0.26 to
 Arrow C Stream boundary. Direct Parquet or direct local-Delta-table reads are
 not conformance evidence.

--- a/tests/testthat/test-api-shape.R
+++ b/tests/testthat/test-api-shape.R
@@ -30,6 +30,17 @@ test_that("the staged object graph composes", {
   expect_s3_class(chg, "SharingChanges")
 })
 
+test_that("change data feeds always use Delta format", {
+  expect_false(
+    "response_format" %in%
+      names(formals(
+        test_client()$table(
+          "sales.default.orders"
+        )$changes
+      ))
+  )
+})
+
 test_that("download concurrency belongs to the table", {
   snapshot <- test_client()$table("sales.default.orders")$snapshot()
 
@@ -128,8 +139,43 @@ test_that("readers validate options interpreted by the package", {
 test_that("print methods are stable", {
   client <- test_client()
   expect_output(print(client), "SharingClient")
-  expect_output(print(client$table("s.sc.t")), "SharingTable")
-  expect_output(print(client$table("s.sc.t")$snapshot()), "SharingSnapshot")
+  expect_output(
+    print(client$table("s.sc.t", concurrency = 8)),
+    "concurrent downloads: 8",
+    fixed = TRUE
+  )
+  expect_output(
+    print(client$table("s.sc.t")$snapshot(limit = 10, columns = "id")),
+    "latest snapshot | 1 column | limit 10",
+    fixed = TRUE
+  )
+  expect_output(
+    print(client$table("s.sc.t")$changes(
+      starting_version = 2,
+      ending_version = 4
+    )),
+    "changes 2 to 4",
+    fixed = TRUE
+  )
+})
+
+test_that("to_arrow checks for Arrow before opening the lazy query", {
+  reader <- test_client()$table("sales.default.orders")$snapshot()
+  state <- rlang::env(opened = FALSE)
+  testthat::with_mocked_bindings(
+    {
+      expect_error(reader$to_arrow(), "mocked missing Arrow", fixed = TRUE)
+      expect_false(state$opened)
+    },
+    require_arrow = function(operation) {
+      stop("mocked missing Arrow", call. = FALSE)
+    },
+    sharing_snapshot_stream = function(...) {
+      state$opened <- TRUE
+      stop("query opened", call. = FALSE)
+    },
+    .package = "delta.sharing"
+  )
 })
 
 test_that("client printing redacts endpoint user information", {

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -6,7 +6,6 @@ test_that("bearer auth applies an Authorization header", {
     bearerToken = "tok"
   ))
   ctx <- sharing_auth_context(p)
-  expect_equal(ctx$kind, "bearer_token")
   req <- ctx$authenticate(httr2::request("https://x.test/api"))
   headers <- httr2::req_get_headers(req, redacted = "reveal")
   expect_equal(headers$Authorization, "Bearer tok")
@@ -53,7 +52,6 @@ test_that("oauth client-credentials builds a context without network I/O", {
     clientSecret = "sec"
   ))
   ctx <- sharing_auth_context(p)
-  expect_equal(ctx$kind, "oauth_client_credentials")
   expect_type(ctx$authenticate, "closure")
 })
 
@@ -72,7 +70,7 @@ test_that("private keys are not read while constructing an auth context", {
   ))
 
   expect_no_error(ctx <- sharing_auth_context(p))
-  expect_equal(ctx$kind, "oauth_jwt_bearer_private_key_jwt")
+  expect_type(ctx$authenticate, "closure")
 })
 
 test_that("OAuth request policies are attached lazily", {

--- a/tests/testthat/test-cdf-conformance.R
+++ b/tests/testthat/test-cdf-conformance.R
@@ -1,0 +1,258 @@
+cdfx_fixture <- function(name) {
+  directory <- c(
+    basic = "b",
+    `column-mapping-name` = "n",
+    `column-mapping-id` = "i",
+    `schema-transition` = "s"
+  )[[name]]
+  fs::path(test_path("fixtures", "cdfx"), directory)
+}
+
+cdfx_file_action_type <- function(action) {
+  purrr::detect(c("add", "remove", "cdc"), \(type) {
+    !is.null(action[[type]])
+  })
+}
+
+cdfx_commits <- function(name) {
+  root <- cdfx_fixture(name)
+  paths <- fs::dir_ls(
+    fs::path(root, "l"),
+    regexp = "[0-9]+\\.json$",
+    type = "file"
+  )
+  commits <- purrr::map(paths, function(path) {
+    actions <- purrr::map(
+      readLines(path, warn = FALSE),
+      jsonlite::fromJSON,
+      simplifyVector = FALSE
+    )
+    commit_info <- purrr::detect(actions, \(action) !is.null(action$commitInfo))
+    list(
+      version = as.numeric(fs::path_ext_remove(fs::path_file(path))),
+      timestamp = commit_info$commitInfo$timestamp,
+      actions = actions
+    )
+  })
+  payload_paths <- commits |>
+    purrr::map("actions") |>
+    purrr::list_flatten() |>
+    purrr::keep(\(action) !is.null(cdfx_file_action_type(action))) |>
+    purrr::map_chr(function(action) {
+      type <- cdfx_file_action_type(action)
+      action[[type]]$path
+    }) |>
+    unique() |>
+    sort()
+  list(root = root, commits = commits, payload_paths = payload_paths)
+}
+
+cdfx_active_action <- function(commits, type, version) {
+  eligible <- purrr::keep(commits, \(commit) commit$version <= version)
+  action <- purrr::detect(
+    rev(eligible),
+    \(commit) purrr::some(commit$actions, \(action) !is.null(action[[type]]))
+  )
+  purrr::detect(action$actions, \(action) !is.null(action[[type]]))[[type]]
+}
+
+cdfx_wire_actions <- function(commit, fixture, start_version) {
+  purrr::map(commit$actions, function(action) {
+    if (commit$version > start_version && !is.null(action$protocol)) {
+      return(list(protocol = list(
+        version = commit$version,
+        deltaProtocol = action$protocol
+      )))
+    }
+    if (commit$version > start_version && !is.null(action$metaData)) {
+      return(list(metaData = list(
+        version = commit$version,
+        deltaMetadata = action$metaData
+      )))
+    }
+
+    type <- cdfx_file_action_type(action)
+    if (is.null(type)) {
+      return(NULL)
+    }
+    payload_index <- match(action[[type]]$path, fixture$payload_paths)
+    source <- fs::path(
+      fixture$root,
+      "p",
+      sprintf("%02d.parquet", payload_index)
+    )
+    local_action <- action[[type]]
+    local_action$path <- local_file_url(source)
+    list(file = list(
+      id = fixture_file_id(source),
+      size = as.numeric(fs::file_size(source)),
+      version = commit$version,
+      timestamp = commit$timestamp,
+      deltaSingleAction = rlang::set_names(list(local_action), type)
+    ))
+  }) |>
+    purrr::compact()
+}
+
+cdfx_actions <- function(name, start_version, end_version) {
+  fixture <- cdfx_commits(name)
+  lines <- list(
+    list(protocol = list(
+      version = start_version,
+      deltaProtocol = cdfx_active_action(
+        fixture$commits,
+        "protocol",
+        start_version
+      )
+    )),
+    list(metaData = list(
+      version = start_version,
+      deltaMetadata = cdfx_active_action(
+        fixture$commits,
+        "metaData",
+        start_version
+      )
+    ))
+  )
+  selected_commits <- purrr::keep(
+    fixture$commits,
+    \(commit) {
+      commit$version >= start_version && commit$version <= end_version
+    }
+  )
+  wire_actions <- selected_commits |>
+    purrr::map(
+      cdfx_wire_actions,
+      fixture = fixture,
+      start_version = start_version
+    ) |>
+    purrr::list_flatten()
+
+  c(lines, wire_actions, list(list(endStreamAction = list())))
+}
+
+cdfx_table <- function(name, actions) {
+  httr2::local_mocked_responses(function(req) {
+    httr2::response(200, body = charToRaw(ndjson_body(actions)))
+  }, env = parent.frame())
+  shared_table <- test_client()$table(
+    paste("fixtures", "default", name, sep = ".")
+  )
+  if (fs::dir_exists(shared_table$cache_path)) {
+    fs::dir_delete(shared_table$cache_path)
+  }
+  withr::defer(
+    if (fs::dir_exists(shared_table$cache_path)) {
+      fs::dir_delete(shared_table$cache_path)
+    },
+    envir = parent.frame()
+  )
+  shared_table
+}
+
+test_that("CDF preserves all four change types", {
+  shared_table <- cdfx_table("cdfx-basic", cdfx_actions("basic", 0, 3))
+  data <- shared_table$changes(
+    starting_version = 0,
+    ending_version = 3,
+    columns = c(
+      "id",
+      "name",
+      "birthday",
+      "_change_type",
+      "_commit_version",
+      "_commit_timestamp"
+    )
+  )$to_tibble(batch_size = 3L)
+
+  expect_identical(nrow(data), 23L)
+  counts <- table(data$`_change_type`)
+  expect_equal(
+    as.numeric(counts[c(
+      "insert",
+      "delete",
+      "update_preimage",
+      "update_postimage"
+    )]),
+    c(10L, 1L, 6L, 6L)
+  )
+  expect_setequal(as.numeric(data$`_commit_version`), 0:3)
+})
+
+test_that("CDF retains logical values for both column mapping modes", {
+  fixtures <- list(
+    list(
+      name = "column-mapping-name",
+      updated = "Bob",
+      before = 200,
+      after = 250,
+      inserted = "David",
+      deleted = "Alice"
+    ),
+    list(
+      name = "column-mapping-id",
+      updated = "Frank",
+      before = 250,
+      after = 275,
+      inserted = "Henry",
+      deleted = "Grace"
+    )
+  )
+
+  purrr::walk(fixtures, function(fixture) {
+    shared_table <- cdfx_table(
+      paste0("cdfx-", fixture$name),
+      cdfx_actions(fixture$name, 1, 4)
+    )
+    data <- shared_table$changes(
+      starting_version = 1,
+      ending_version = 4,
+      columns = c("id", "name", "value", "_change_type", "_commit_version")
+    )$to_tibble(batch_size = 2L)
+
+    expect_identical(nrow(data), 4L)
+    expect_setequal(
+      data$`_change_type`,
+      c("update_preimage", "update_postimage", "insert", "delete")
+    )
+    update <- data[data$name == fixture$updated, ]
+    expect_setequal(
+      update$`_change_type`,
+      c("update_preimage", "update_postimage")
+    )
+    expect_setequal(as.numeric(update$value), c(fixture$before, fixture$after))
+    expect_equal(
+      as.numeric(data$`_commit_version`[data$name == fixture$inserted]),
+      3
+    )
+    expect_equal(
+      as.numeric(data$`_commit_version`[data$name == fixture$deleted]),
+      4
+    )
+  })
+})
+
+test_that("CDF bounds isolate an incompatible schema transition", {
+  compatible <- cdfx_table(
+    "cdfx-schema-compatible",
+    cdfx_actions("schema-transition", 3, 3)
+  )
+  data <- compatible$changes(
+    starting_version = 3,
+    ending_version = 3
+  )$to_tibble()
+  expect_identical(nrow(data), 0L)
+
+  incompatible <- cdfx_table(
+    "cdfx-schema-incompatible",
+    cdfx_actions("schema-transition", 3, 4)
+  )
+  expect_error(
+    incompatible$changes(
+      starting_version = 3,
+      ending_version = 4
+    )$to_tibble(),
+    "Delta Kernel CDF preparation failed",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-cdf-read-execution.R
+++ b/tests/testthat/test-cdf-read-execution.R
@@ -179,7 +179,14 @@ test_that("prepared CDF logs span the effective response range", {
     )
   )
 
-  log <- prepare_cdf_log(protocol, by_version, 1, 3)
+  log <- prepare_cdf_query_log(list(
+    protocol = protocol,
+    by_version = by_version,
+    start_version = 1,
+    end_version = 3,
+    downloaded = 2L,
+    cache_hits = 1L
+  ))
   withr::defer(fs::dir_delete(log$root))
   log_dir <- fs::path(log$path, "_delta_log")
   entries <- fs::dir_ls(log_dir, type = "file") |>
@@ -188,6 +195,8 @@ test_that("prepared CDF logs span the effective response range", {
 
   expect_equal(log$start_version, 1)
   expect_equal(log$end_version, 3)
+  expect_equal(log$downloaded, 2L)
+  expect_equal(log$cache_hits, 1L)
   expect_setequal(
     entries,
     c(

--- a/tests/testthat/test-discovery.R
+++ b/tests/testthat/test-discovery.R
@@ -12,7 +12,7 @@ mock_discovery <- function(req) {
   }
   if (grepl("/shares/sales/schemas$", path)) {
     return(httr2::response_json(
-      body = list(items = list(list(name = "default")))
+      body = list(items = list(list(name = "default", share = "sales")))
     ))
   }
   if (grepl("/tables$", path)) {
@@ -77,7 +77,34 @@ test_that("list_schemas scopes to a share", {
   httr2::local_mocked_responses(mock_discovery)
   schemas <- client$list_schemas(share = "sales")
   expect_equal(schemas[[1]], list(share = "sales", name = "default"))
+  expect_identical(names(schemas[[1]]), c("share", "name"))
   expect_output(print(schemas), "sales.default", fixed = TRUE)
+})
+
+test_that("list_schemas fills a missing server share", {
+  client <- test_client()
+  httr2::local_mocked_responses(function(req) {
+    httr2::response_json(body = list(items = list(list(name = "default"))))
+  })
+
+  schemas <- client$list_schemas(share = "sales")
+
+  expect_identical(schemas[[1]], list(share = "sales", name = "default"))
+})
+
+test_that("listing print methods truncate long results", {
+  shares <- structure(
+    purrr::map(seq_len(12L), \(index) list(name = paste0("share-", index))),
+    class = c("delta_sharing_listing", "list"),
+    kind = "shares"
+  )
+
+  output <- capture.output(returned <- print(shares))
+
+  expect_identical(returned, shares)
+  expect_true(any(grepl("share-10", output, fixed = TRUE)))
+  expect_false(any(grepl("share-11", output, fixed = TRUE)))
+  expect_true(any(grepl("... and 2 more", output, fixed = TRUE)))
 })
 
 test_that("list_tables returns qualified table records", {

--- a/tests/testthat/test-duckdb.R
+++ b/tests/testthat/test-duckdb.R
@@ -63,6 +63,9 @@ test_that("DuckDB early completion releases the Arrow stream", {
   skip_if_not_installed("DBI")
   skip_if_not_installed("duckdb")
 
+  # Early completion does not exhaust the one-pass reader, so serialize pulls.
+  withr::local_options(arrow.use_threads = FALSE)
+
   httr2::local_mocked_responses(function(req) {
     httr2::response(
       200,

--- a/tests/testthat/test-duckdb.R
+++ b/tests/testthat/test-duckdb.R
@@ -1,11 +1,9 @@
-test_that("DuckDB queries lazy snapshot readers", {
+test_that("DuckDB queries lazy snapshot readers with default Arrow threads", {
   skip_if_not_installed("arrow")
   skip_if_not_installed("DBI")
   skip_if_not_installed("duckdb")
 
-  # DuckDB wraps lazy readers in an Arrow scanner. Arrow C streams are not
-  # assumed to support concurrent pulls, so keep this scanner serialized.
-  withr::local_options(arrow.use_threads = FALSE)
+  withr::local_options(arrow.use_threads = TRUE)
 
   stream <- native_snapshot_stream(
     fixture_table("local-table"),
@@ -13,8 +11,8 @@ test_that("DuckDB queries lazy snapshot readers", {
   )
   reader <- sharing_stream_to_arrow_reader(stream)
   withr::defer(reader$Close())
-  connection <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
-  withr::defer(DBI::dbDisconnect(connection, shutdown = TRUE))
+  connection <- DBI::dbConnect(duckdb::duckdb())
+  withr::defer(DBI::dbDisconnect(connection))
   duckdb::duckdb_register_arrow(connection, "shared_orders", reader)
   withr::defer(
     duckdb::duckdb_unregister_arrow(connection, "shared_orders")
@@ -43,8 +41,8 @@ test_that("DuckDB queries eager Arrow tables", {
   table <- sharing_stream_to_arrow(
     native_snapshot_stream(fixture_table("local-table"))
   )
-  connection <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
-  withr::defer(DBI::dbDisconnect(connection, shutdown = TRUE))
+  connection <- DBI::dbConnect(duckdb::duckdb())
+  withr::defer(DBI::dbDisconnect(connection))
   duckdb::duckdb_register_arrow(connection, "shared_orders", table)
   withr::defer(
     duckdb::duckdb_unregister_arrow(connection, "shared_orders")
@@ -64,8 +62,6 @@ test_that("DuckDB early completion releases the Arrow stream", {
   skip_if_not_installed("arrow")
   skip_if_not_installed("DBI")
   skip_if_not_installed("duckdb")
-
-  withr::local_options(arrow.use_threads = FALSE)
 
   httr2::local_mocked_responses(function(req) {
     httr2::response(
@@ -94,10 +90,10 @@ test_that("DuckDB early completion releases the Arrow stream", {
     )
     reader <- sharing_stream_to_arrow_reader(stream)
     withr::defer(reader$Close())
-    connection <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
+    connection <- DBI::dbConnect(duckdb::duckdb())
     withr::defer(
       if (DBI::dbIsValid(connection)) {
-        DBI::dbDisconnect(connection, shutdown = TRUE)
+        DBI::dbDisconnect(connection)
       }
     )
     duckdb::duckdb_register_arrow(connection, "shared_orders", reader)
@@ -112,7 +108,7 @@ test_that("DuckDB early completion releases the Arrow stream", {
       "SELECT * FROM shared_orders LIMIT 1"
     )
     duckdb::duckdb_unregister_arrow(connection, "shared_orders")
-    DBI::dbDisconnect(connection, shutdown = TRUE)
+    DBI::dbDisconnect(connection)
     result
   })
 
@@ -126,8 +122,6 @@ test_that("DuckDB queries CDF metadata columns", {
   skip_if_not_installed("DBI")
   skip_if_not_installed("duckdb")
 
-  withr::local_options(arrow.use_threads = FALSE)
-
   stream <- native_cdf_stream(
     fixture_table("cdf"),
     start_version = 1,
@@ -135,8 +129,8 @@ test_that("DuckDB queries CDF metadata columns", {
   )
   reader <- sharing_stream_to_arrow_reader(stream)
   withr::defer(reader$Close())
-  connection <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE))
-  withr::defer(DBI::dbDisconnect(connection, shutdown = TRUE))
+  connection <- DBI::dbConnect(duckdb::duckdb())
+  withr::defer(DBI::dbDisconnect(connection))
   duckdb::duckdb_register_arrow(connection, "shared_changes", reader)
   withr::defer(
     duckdb::duckdb_unregister_arrow(connection, "shared_changes")

--- a/tests/testthat/test-e2e-kernel-read.R
+++ b/tests/testthat/test-e2e-kernel-read.R
@@ -3,6 +3,10 @@
 # exercise the native reader, Arrow C stream, and nanoarrow conversion without a
 # network mock. This is the layer unit tests with httr2 mocks cannot cover.
 
+test_stream_to_data_frame <- function(stream) {
+  as.data.frame(sharing_stream_to_tibble(stream))
+}
+
 corrupt_snapshot_fixture <- function() {
   table <- fs::path(
     withr::local_tempdir(
@@ -33,7 +37,7 @@ test_that("the installed native API contains only production entry points", {
 
 test_that("kernel reads a local table to a data frame", {
   stream <- native_snapshot_stream(fixture_table("local-table"))
-  df <- sharing_stream_to_data_frame(stream)
+  df <- test_stream_to_data_frame(stream)
 
   expect_s3_class(df, "data.frame")
   expect_false(inherits(df, "tbl_df"))
@@ -78,12 +82,11 @@ test_that("data-frame materialization preserves native stream failures", {
   )
 
   condition <- expect_error(
-    sharing_stream_to_data_frame(stream),
+    test_stream_to_data_frame(stream),
     "Delta Kernel data scan failed",
     fixed = TRUE
   )
   expect_s3_class(condition, "simpleError")
-  expect_false(inherits(condition, "delta_sharing_kernel_error"))
   expect_match(capture.output(print(stream)), "invalid pointer")
 })
 
@@ -170,7 +173,6 @@ test_that("Arrow materialization preserves native stream failures", {
     fixed = TRUE
   )
   expect_s3_class(condition, "simpleError")
-  expect_false(inherits(condition, "delta_sharing_kernel_error"))
   expect_match(capture.output(print(stream)), "invalid pointer")
 })
 
@@ -179,7 +181,7 @@ test_that("projection selects and orders columns", {
     fixture_table("local-table"),
     columns = c("active", "id")
   )
-  df <- sharing_stream_to_data_frame(stream)
+  df <- test_stream_to_data_frame(stream)
   expect_equal(names(df), c("active", "id"))
 })
 
@@ -188,7 +190,7 @@ test_that("partition-only projection does not require a visible data column", {
     fixture_table("timestamp-ntz"),
     columns = "region"
   )
-  df <- sharing_stream_to_data_frame(stream)
+  df <- test_stream_to_data_frame(stream)
 
   expect_identical(names(df), "region")
   expect_gt(nrow(df), 0L)
@@ -197,13 +199,13 @@ test_that("partition-only projection does not require a visible data column", {
 
 test_that("limit is enforced exactly by the kernel scan", {
   stream <- native_snapshot_stream(fixture_table("local-table"), limit = 4)
-  df <- sharing_stream_to_data_frame(stream)
+  df <- test_stream_to_data_frame(stream)
   expect_equal(nrow(df), 4L)
 })
 
 test_that("logical types round-trip through the kernel", {
   stream <- native_snapshot_stream(fixture_table("logical-types"))
-  df <- sharing_stream_to_data_frame(stream)
+  df <- test_stream_to_data_frame(stream)
   expect_s3_class(df, "data.frame")
   expect_gt(nrow(df), 0L)
 })
@@ -270,7 +272,7 @@ test_that("native CDF reads the local change fixture", {
     end_version = 2,
     columns = c("id", "_change_type")
   )
-  changes <- sharing_stream_to_data_frame(stream)
+  changes <- test_stream_to_data_frame(stream)
 
   expect_gt(nrow(changes), 0L)
   expect_identical(names(changes), c("id", "_change_type"))
@@ -312,7 +314,7 @@ test_that("snapshot and CDF readers stage selected files before Kernel reads", {
     table_download_cache(profile, identifier),
     concurrency = 4L
   ) |>
-    sharing_stream_to_data_frame()
+    test_stream_to_data_frame()
   expect_equal(nrow(snapshot), 7L)
 
   state$operation <- "cdf"
@@ -325,13 +327,12 @@ test_that("snapshot and CDF readers stage selected files before Kernel reads", {
       ending_version = 2,
       starting_timestamp = NULL,
       ending_timestamp = NULL,
-      columns = c("id", "_change_type"),
-      response_format = "delta"
+      columns = c("id", "_change_type")
     ),
     table_download_cache(profile, identifier),
     concurrency = 4L
   ) |>
-    sharing_stream_to_data_frame()
+    test_stream_to_data_frame()
 
   expect_gt(nrow(changes), 0L)
   expect_identical(names(changes), c("id", "_change_type"))
@@ -370,7 +371,6 @@ test_that("native condition handling releases streams and preserves errors", {
     fixed = TRUE
   )
   expect_s3_class(condition, "simpleError")
-  expect_false(inherits(condition, "delta_sharing_kernel_error"))
   expect_match(capture.output(print(failed_stream)), "invalid pointer")
 
   original <- simpleError("construction failed")
@@ -441,8 +441,7 @@ test_that("public CDF readers paginate and materialize local change files", {
   })
   changes <- test_client()$table("sales.default.changes")$changes(
     starting_version = 1,
-    ending_version = 2,
-    response_format = "delta"
+    ending_version = 2
   )$to_data_frame()
 
   expect_identical(state$page, 2L)
@@ -455,16 +454,4 @@ test_that("public CDF readers paginate and materialize local change files", {
     ) %in%
       names(changes)
   ))
-})
-
-test_that("parquet CDF is rejected before any request", {
-  changes <- test_client()$table("sales.default.changes")$changes(
-    starting_version = 1,
-    response_format = "parquet"
-  )
-
-  expect_error(
-    changes$to_arrow_stream(),
-    class = "delta_sharing_unsupported_error"
-  )
 })

--- a/tests/testthat/test-feature-conformance.R
+++ b/tests/testthat/test-feature-conformance.R
@@ -1,0 +1,182 @@
+feature_snapshot_actions <- function(fixture) {
+  root <- fixture_table(fixture)
+  purrr::map(fixture_commit_actions(fixture, 0L), function(action) {
+    if (!is.null(action$protocol)) {
+      return(list(protocol = list(deltaProtocol = action$protocol)))
+    }
+    if (!is.null(action$metaData)) {
+      return(list(metaData = list(deltaMetadata = action$metaData)))
+    }
+
+    add <- action$add
+    source <- fs::path(root, add$path)
+    add$path <- local_file_url(source)
+    list(file = list(
+      id = fixture_file_id(source),
+      size = as.numeric(fs::file_size(source)),
+      deltaSingleAction = list(add = add)
+    ))
+  })
+}
+
+feature_snapshot_table <- function(fixture, actions) {
+  httr2::local_mocked_responses(function(req) {
+    httr2::response(200, body = charToRaw(ndjson_body(actions)))
+  }, env = parent.frame())
+  shared_table <- test_client()$table(
+    paste("fixtures", "default", fixture, sep = ".")
+  )
+  if (fs::dir_exists(shared_table$cache_path)) {
+    fs::dir_delete(shared_table$cache_path)
+  }
+  withr::defer(
+    if (fs::dir_exists(shared_table$cache_path)) {
+      fs::dir_delete(shared_table$cache_path)
+    },
+    envir = parent.frame()
+  )
+  shared_table
+}
+
+test_that("column mapping restores logical data and partition names", {
+  fixture <- "column-mapping"
+  shared_table <- feature_snapshot_table(
+    fixture,
+    feature_snapshot_actions(fixture)
+  )
+  data <- shared_table$snapshot(
+    columns = c("region", "id", "value"),
+    response_format = "delta"
+  )$to_tibble(batch_size = 2L)
+
+  expect_named(data, c("region", "id", "value"))
+  expect_identical(data$region, rep("apac", 3L))
+  expect_equal(data$id, c(10, 11, 12))
+  expect_identical(data$value, c("alpha", "beta", "gamma"))
+})
+
+test_that("column mapping by ID follows Parquet field IDs", {
+  fixture <- "column-mapping-id"
+  shared_table <- feature_snapshot_table(
+    fixture,
+    feature_snapshot_actions(fixture)
+  )
+  data <- shared_table$snapshot(
+    columns = c("value", "region", "id"),
+    response_format = "delta"
+  )$to_tibble(batch_size = 2L)
+
+  expect_named(data, c("value", "region", "id"))
+  expect_identical(data$value, c("delta", "kernel", "arrow"))
+  expect_identical(data$region, rep("latam", 3L))
+  expect_equal(data$id, c(31, 32, 33))
+})
+
+test_that("deletion vectors remove rows before materialization", {
+  fixture <- "deletion-vectors"
+  shared_table <- feature_snapshot_table(
+    fixture,
+    feature_snapshot_actions(fixture)
+  )
+  data <- shared_table$snapshot(response_format = "delta")$to_tibble(
+    batch_size = 2L
+  )
+
+  expect_equal(data$id, c(0, 2, 4))
+  expect_identical(data$value, c("zero", "two", "four"))
+  expect_false(any(data$id %in% c(1, 3)))
+})
+
+test_that("timestamp without timezone and its partition survive staging", {
+  fixture <- "timestamp-ntz"
+  shared_table <- feature_snapshot_table(
+    fixture,
+    feature_snapshot_actions(fixture)
+  )
+  snapshot <- shared_table$snapshot(
+    columns = c("observed_at", "region", "id"),
+    response_format = "delta"
+  )
+  stream <- snapshot$to_arrow_stream(batch_size = 1L)
+  withr::defer(release_materializer_stream(stream))
+  expect_identical(stream$get_schema()$children$observed_at$format, "tsu:")
+
+  data <- snapshot$to_tibble(batch_size = 1L)
+  expect_identical(data$region, rep("emea", 2L))
+  expect_equal(data$id, c(21, 22))
+  expect_equal(
+    as.numeric(data$observed_at),
+    c(1767323045.123456, 1780819750.654321),
+    tolerance = 1e-6
+  )
+})
+
+test_that("mapped logical types survive the complete Sharing read path", {
+  fixture <- "logical-types"
+  shared_table <- feature_snapshot_table(
+    fixture,
+    feature_snapshot_actions(fixture)
+  )
+  snapshot <- shared_table$snapshot(response_format = "delta")
+  stream <- snapshot$to_arrow_stream(batch_size = 2L)
+  withr::defer(release_materializer_stream(stream))
+  schema <- stream$get_schema()
+
+  expect_identical(schema$children$amount$format, "d:18,4")
+  expect_identical(schema$children$metrics$format, "+m")
+  expect_identical(schema$children$observed_at$format, "tsu:UTC")
+  expect_identical(schema$children$local_at$format, "tsu:")
+
+  data <- snapshot$to_tibble(batch_size = 2L)
+  expect_named(
+    data,
+    c("id", "amount", "metrics", "observed_at", "local_at", "profile")
+  )
+  expect_equal(data$id, c(101, 102, 103))
+  expect_equal(data$amount, c(12345.6789, -0.01, NA))
+  expect_identical(data$metrics[[1L]]$key, c("alpha", "beta"))
+  expect_equal(data$metrics[[1L]]$value, c(1.25, -2.5))
+  expect_null(data$metrics[[3L]])
+  expect_equal(data$profile$score, c(7.125, 8.5, NA))
+  expect_identical(
+    data$profile$contact$label,
+    c("first", NA_character_, "third")
+  )
+  expect_identical(
+    data$profile$events[[1L]]$code,
+    c("open", "close")
+  )
+})
+
+test_that("snapshot types survive the complete Sharing read path", {
+  fixture <- "snapshot-types"
+  shared_table <- feature_snapshot_table(
+    fixture,
+    feature_snapshot_actions(fixture)
+  )
+  data <- shared_table$snapshot(response_format = "delta")$to_tibble(
+    batch_size = 2L
+  )
+
+  expect_equal(data$id, c(1, 2, 3))
+  expect_identical(data$flag, c(TRUE, FALSE, NA))
+  expect_identical(data$tiny, c(-128L, 0L, 127L))
+  expect_identical(data$small, c(-32768L, 0L, 32767L))
+  expect_identical(data$count, c(10L, 20L, 30L))
+  expect_equal(data$ratio, c(1.25, NA, 3.5))
+  expect_equal(data$measure, c(1.5, 2.5, NA))
+  expect_identical(data$label, c("alpha", "beta", NA))
+  expect_identical(data$payload[[1L]], charToRaw("A"))
+  expect_identical(data$payload[[2L]], as.raw(c(0, 255)))
+  expect_null(data$payload[[3L]])
+  expect_identical(
+    data$event_date,
+    as.Date(c("2025-01-02", "2025-06-07", NA))
+  )
+  expect_identical(attr(data$event_at, "tzone"), "UTC")
+  expect_identical(data$tags[[1L]], c("red", "blue"))
+  expect_identical(data$tags[[2L]], character())
+  expect_null(data$tags[[3L]])
+  expect_identical(data$details$score, c(7L, 8L, NA))
+  expect_identical(data$details$note, c("left", NA, "right"))
+})

--- a/tests/testthat/test-kernel-log.R
+++ b/tests/testthat/test-kernel-log.R
@@ -21,7 +21,13 @@ test_that("delta format writes protocol, metadata, and verbatim actions", {
       )
     )
   )
-  lines <- synthetic_log_lines("delta", proto, meta, files, "read")
+  lines <- c(
+    synthetic_log_header("delta", proto, meta, "read"),
+    purrr::map_chr(
+      files,
+      \(file) log_json_line(synthetic_file_action(file, "delta", "read"))
+    )
+  )
 
   expect_length(lines, 4L)
   purrr::walk(lines, \(line) expect_no_error(jsonlite::fromJSON(line)))
@@ -46,7 +52,13 @@ test_that("parquet format synthesizes a flat add with object-valued maps", {
       )
     )
   )
-  lines <- synthetic_log_lines("parquet", proto, meta, files, "read")
+  lines <- c(
+    synthetic_log_header("parquet", proto, meta, "read"),
+    purrr::map_chr(
+      files,
+      \(file) log_json_line(synthetic_file_action(file, "parquet", "read"))
+    )
+  )
 
   add <- jsonlite::fromJSON(lines[[3]])
   expect_equal(add$add$path, "https://s/p1")
@@ -57,12 +69,15 @@ test_that("parquet format synthesizes a flat add with object-valued maps", {
   expect_true(is.list(metaline$metaData$configuration))
 })
 
-test_that("prepare_synthetic_log writes the session-temporary layout", {
+test_that("prepare_log writes the session-temporary layout", {
   lines <- c(
     '{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}',
     '{"metaData":{"id":"t"}}'
   )
-  log <- prepare_synthetic_log(lines)
+  log <- prepare_log(function(log_dir) {
+    writeLines(lines, fs::path(log_dir, log_commit_name), useBytes = TRUE)
+    invisible(NULL)
+  })
   withr::defer(fs::dir_delete(log$root))
 
   # root is a .delta-sharing-snapshot-* dir; table location is <root>/table

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -85,6 +85,7 @@ test_that("table protocol projects delta reader features", {
   expect_equal(proto$response_format, "delta")
   expect_equal(proto$min_reader_version, 3L)
   expect_true("columnMapping" %in% proto$reader_features)
+  expect_output(print(proto), "<Delta Sharing protocol> delta", fixed = TRUE)
 })
 
 test_that("table metadata exposes safe fields", {
@@ -97,6 +98,7 @@ test_that("table metadata exposes safe fields", {
   expect_equal(meta$size, 3000000000)
   expect_equal(meta$created_time, 1720000000000)
   expect_null(meta$location)
+  expect_output(print(meta), "table version: 42", fixed = TRUE)
 })
 
 test_that("table schema parses the struct schema", {
@@ -105,6 +107,27 @@ test_that("table schema parses the struct schema", {
   schema <- tbl$schema()
   expect_equal(schema$type, "struct")
   expect_equal(schema$fields[[1]]$name, "id")
+  expect_output(print(schema), "<Delta Sharing schema> 1 field", fixed = TRUE)
+})
+
+test_that("schema printing is compact and preserves the list", {
+  schema <- structure(
+    list(
+      type = "struct",
+      fields = purrr::map(
+        seq_len(12L),
+        \(index) list(name = paste0("column_", index), type = "string")
+      )
+    ),
+    class = c("delta_sharing_schema", "list")
+  )
+
+  output <- capture.output(returned <- print(schema))
+
+  expect_identical(returned, schema)
+  expect_true(any(grepl("column_10", output, fixed = TRUE)))
+  expect_false(any(grepl("column_11", output, fixed = TRUE)))
+  expect_true(any(grepl("... and 2 more", output, fixed = TRUE)))
 })
 
 test_that("automatic response format is cached within one client", {
@@ -251,6 +274,17 @@ test_that("metadata protocol validation rejects invalid wire responses", {
   expect_error(
     parse_version_header(invalid_version, "table_version"),
     class = "delta_sharing_protocol_error"
+  )
+  malformed_version <- httr2::response(
+    200,
+    headers = list(`delta-table-version` = "unknown")
+  )
+  expect_warning(
+    expect_error(
+      parse_version_header(malformed_version, "table_version"),
+      class = "delta_sharing_protocol_error"
+    ),
+    "NAs introduced by coercion"
   )
   expect_error(
     parse_ndjson_lines("{not-json", "metadata"),

--- a/vignettes/delta-sharing.Rmd
+++ b/vignettes/delta-sharing.Rmd
@@ -62,8 +62,9 @@ client <- sharing_client("~/config.share")
 - a path to a `.share` file; or
 - a parsed list.
 
-Profile versions 1 and 2 support bearer tokens, basic auth, OAuth client
-credentials, and private-key JWT bearer authentication.
+Profile version 1 supports bearer tokens. Version 2 supports bearer tokens,
+basic auth, OAuth client credentials, and private-key JWT bearer
+authentication.
 
 Creating the client is offline: it parses the profile without making a request
 or exchanging a token. When authentication is first needed, `httr2` handles
@@ -119,18 +120,22 @@ data_tbl <- snapshot$to_tibble()
 # A base data frame wrapper over the tibble materializer.
 df <- snapshot$to_data_frame()
 
-# Lazy Arrow C stream (use when the result may not fit in memory).
-stream <- snapshot$to_arrow_stream(batch_size = 65536L)
+# Lazy Arrow C stream after selected files have been staged locally.
+stream <- snapshot$to_arrow_stream()
 # Pass the stream to a compatible consumer, or release it when unused.
 stream$release()
 
-# Lazy Arrow reader for consumers such as DuckDB.
+# Lazy Arrow reader for consumers such as DuckDB (requires {arrow}).
 reader <- snapshot$to_arrow_reader()
 reader$Close()
 
 # Eager Arrow table (requires the optional {arrow} package).
 arrow_table <- snapshot$to_arrow()
 ```
+
+Each materializer call performs its own read through the same Arrow C stream
+path. `to_arrow_stream()` and `to_arrow_reader()` stream rows lazily; the files
+selected by the sharing server are staged in the session cache first.
 
 Read a specific version or point in time:
 
@@ -143,10 +148,10 @@ orders$snapshot(timestamp = "2024-01-01T00:00:00Z")$to_tibble()
 `limit` is enforced exactly by the Kernel scan. A `predicate` is a best-effort
 server hint, not an exact row filter.
 
-The default `response_format = "auto"` is negotiated once per table within a
-client and reused by later reads. Explicit `"delta"` or `"parquet"` values
-bypass negotiation. Table metadata and schema methods continue to fetch their
-current values.
+For snapshots, the default `response_format = "auto"` is negotiated once per
+table within a client and reused by later reads. Explicit `"delta"` or
+`"parquet"` values bypass negotiation. Table metadata and schema methods
+continue to fetch their current values.
 
 Predicates use ordinary nested R lists. The package serializes the list to the
 JSON-string wire field required by Delta Sharing:
@@ -181,7 +186,7 @@ Downloads are cached for the R session. New handles for the same endpoint and
 table reuse the same files:
 
 ```{r, eval = FALSE}
-orders <- client$table("sales.default.orders", concurrency = 4)
+orders <- client$table("sales.default.orders")
 
 first <- orders$snapshot()$to_tibble()
 second <- orders$snapshot()$to_tibble() # reuses unchanged data files
@@ -190,9 +195,9 @@ orders$cache_path
 ```
 
 `concurrency` controls the maximum number of concurrent downloads and defaults
-to four. R removes the cache with its session temporary directory. Advanced
-users can remove `orders$cache_path` manually, but should not do so while a lazy
-reader is active; the next read recreates it.
+to four. The cache is stored in R's session temporary directory and is normally
+removed when R exits. Advanced users can remove `orders$cache_path` manually,
+but should not do so while a lazy reader is active; the next read recreates it.
 
 In an interactive R session, missing-file downloads show their file count and,
 when the server supplies sizes, the total bytes to download.
@@ -208,7 +213,8 @@ A read follows one path:
    cached local files.
 4. Delta Kernel reads through that log and exposes the rows as an Arrow stream.
 
-Delta and Parquet responses, including change data feeds, use this path. Delta
+Snapshots support Delta and Parquet responses through this path. Change data
+feeds require Delta responses and use the same local staging approach. Delta
 Kernel remains responsible for projection, deletion vectors, column mapping,
 change semantics, and Arrow batches.
 


### PR DESCRIPTION
## Summary

- simplify and verify README and vignette guidance, including the public demo profile, materializer behavior, snapshot negotiation, caching, and DuckDB interop
- tighten the read API by making CDF Delta-only, improving object printing, fixing schema discovery records, and checking for Arrow before opening a query
- add production-path conformance coverage for deletion vectors, column mapping, logical and nested types, timestamp NTZ, and CDF semantics
- remove only the internal helpers and metadata reviewed as dead or redundant; retain profile metadata and read telemetry

## Validation

- `devtools::test()`: pass
- `cargo check --locked`: pass
- `cargo clippy --locked --all-targets -- -D warnings`: pass
- `cargo test --locked`: 9 passed
- full `R CMD check --as-cran`: 0 errors, 0 warnings; expected new-submission/time notes plus an R6 namespace note
- restored the required R6 namespace import and reran the static tarball check: `Status: OK`
- secret-pattern scan and repository pre-commit/pre-push scans: pass